### PR TITLE
feat: Add Fossa config

### DIFF
--- a/fossa-deps.yml
+++ b/fossa-deps.yml
@@ -1,0 +1,40 @@
+remote-dependencies:
+  - name: gavinbunney/kubectl
+    version: "1.19.0"
+    url: https://github.com/gavinbunney/terraform-provider-kubectl
+
+  - name: hashicorp/aws
+    version: "5.100.0"
+    url: https://github.com/hashicorp/terraform-provider-aws
+
+  - name: hashicorp/cloudinit
+    version: "2.3.7"
+    url: https://github.com/hashicorp/terraform-provider-cloudinit
+
+  - name: hashicorp/external
+    version: "2.3.5"
+    url: https://github.com/hashicorp/terraform-provider-external
+
+  - name: hashicorp/helm
+    version: "3.0.2"
+    url: https://github.com/hashicorp/terraform-provider-helm
+
+  - name: hashicorp/kubernetes
+    version: "2.38.0"
+    url: https://github.com/hashicorp/terraform-provider-kubernetes
+
+  - name: hashicorp/null
+    version: "3.2.4"
+    url: https://github.com/hashicorp/terraform-provider-null
+
+  - name: hashicorp/random
+    version: "3.7.2"
+    url: https://github.com/hashicorp/terraform-provider-random
+
+  - name: hashicorp/time
+    version: "0.13.1"
+    url: https://github.com/hashicorp/terraform-provider-time
+
+  - name: hashicorp/tls
+    version: "4.1.0"
+    url: https://github.com/hashicorp/terraform-provider-tls


### PR DESCRIPTION
I don't know if this works as intended, but I converted the terraform lock file to fossa-deps.yml and the CLI tool seems to notice the deps correctly:

```
vscode ➜ /workspaces/gooddata-cn-terraform (fossa) $ fossa analyze -o
Skipping ficus snippet scanning (--x-snippet-scan not set)

Scan Summary
------------
fossa-cli version 3.11.2 (revision 0cb2e261ec5b compiled with ghc-9.8)
fossa endpoint server version: N/A

1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings

-
* fossa-deps file analysis: succeeded
  ** gavinbunney/kubectl (remote)
  ** hashicorp/aws (remote)
  ** hashicorp/cloudinit (remote)
  ** hashicorp/external (remote)
  ** hashicorp/helm (remote)
  ** hashicorp/kubernetes (remote)
  ** hashicorp/null (remote)
  ** hashicorp/random (remote)
  ** hashicorp/time (remote)
  ** hashicorp/tls (remote)

Notes
-----
* Some projects may not appear in the summary if they were filtered during discovery.
You can run `fossa list-targets` to see all discoverable projects.

* Some projects analysis may be skipped, due to default filters.
Learn more: https://github.com/fossas/fossa-cli/blob/v3.11.2/docs/references/subcommands/analyze.md#what-are-the-default-path-filters

* You can pass `--debug` option to eagerly show all warning and failure messages.

You can also view analysis summary with warning and error messages at: "/tmp/fossa-analyze-scan-summary.txt"
------------
{"projects":[],"sourceUnits":[{"AdditionalDependencyData":{"RemoteDependencies":[{"Description":null,"Homepage":null,"Name":"gavinbunney/kubectl","Url":"https://github.com/gavinbunney/terraform-provider-kubectl","Version":"1.19.0"},{"Description":null,"Homepage":null,"Name":"hashicorp/aws","Url":"https://github.com/hashicorp/terraform-provider-aws","Version":"5.100.0"},{"Description":null,"Homepage":null,"Name":"hashicorp/cloudinit","Url":"https://github.com/hashicorp/terraform-provider-cloudinit","Version":"2.3.7"},{"Description":null,"Homepage":null,"Name":"hashicorp/external","Url":"https://github.com/hashicorp/terraform-provider-external","Version":"2.3.5"},{"Description":null,"Homepage":null,"Name":"hashicorp/helm","Url":"https://github.com/hashicorp/terraform-provider-helm","Version":"3.0.2"},{"Description":null,"Homepage":null,"Name":"hashicorp/kubernetes","Url":"https://github.com/hashicorp/terraform-provider-kubernetes","Version":"2.38.0"},{"Description":null,"Homepage":null,"Name":"hashicorp/null","Url":"https://github.com/hashicorp/terraform-provider-null","Version":"3.2.4"},{"Description":null,"Homepage":null,"Name":"hashicorp/random","Url":"https://github.com/hashicorp/terraform-provider-random","Version":"3.7.2"},{"Description":null,"Homepage":null,"Name":"hashicorp/time","Url":"https://github.com/hashicorp/terraform-provider-time","Version":"0.13.1"},{"Description":null,"Homepage":null,"Name":"hashicorp/tls","Url":"https://github.com/hashicorp/terraform-provider-tls","Version":"4.1.0"}],"UserDefinedDependencies":null},"Build":null,"Data":null,"Files":null,"GraphBreadth":"complete","Info":null,"Manifest":"/workspaces/gooddata-cn-terraform/","Name":"/workspaces/gooddata-cn-terraform/","NoticeFiles":[],"OriginPaths":["fossa-deps.yml"],"Title":null,"Type":"user-specific-yaml"}]}vscode ➜ /workspaces/gooddata-cn-terraform (fossa) $ 
```