### PR TITLE
feat(devcontainer): add Claude Code, Node.js, and Homebrew support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,12 @@
       "installDockerBuildx": true,
       "version": "latest",
       "enableNonRootDocker": "true"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/meaningful-ooo/devcontainer-features/homebrew:2": {
+      "shallow": false
     }
   },
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -18,6 +18,18 @@ done
 sudo apt-get update
 sudo apt-get install -y openjdk-21-jre-headless vim jq unzip
 
+# Install Claude Code (requires Node/npm from devcontainer feature)
+if ! command -v claude >/dev/null 2>&1; then
+  npm install -g @anthropic-ai/claude-code
+fi
+
+# Ensure Homebrew is available in non-interactive shells too
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
 # Install Tinkey
 sudo curl -fsSL -o /tmp/tinkey.tgz https://storage.googleapis.com/tinkey/tinkey-${TINKEY_VERSION}.tar.gz
 sudo tar -xzf /tmp/tinkey.tgz -C /usr/local/bin tinkey tinkey_deploy.jar


### PR DESCRIPTION
Add devcontainer features for Node.js (LTS) and Homebrew, and install Claude Code CLI globally via npm during setup. Homebrew shellenv is sourced for non-interactive shells to ensure consistent tool availability.