### PR TITLE
feat(observability): add Grafana datasources, Redis monitoring, etc..

### DIFF
--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -20,6 +20,23 @@ resource "random_password" "local_postgres_password" {
   override_special = "_-"
 }
 
+resource "helm_release" "prometheus_operator_crds" {
+  count = var.enable_observability ? 1 : 0
+
+  name             = "prometheus-operator-crds"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-operator-crds"
+  namespace        = "kube-system"
+  create_namespace = false
+  # renovate: depName=prometheus-operator-crds registryUrl=https://prometheus-community.github.io/helm-charts
+  version = var.helm_prometheus_operator_crds_version
+
+  wait    = true
+  timeout = 300
+
+  depends_on = [null_resource.k3d_cluster]
+}
+
 module "k8s_local" {
   source = "../modules/k8s-local"
 
@@ -38,6 +55,8 @@ module "k8s_local" {
   kubeconfig_path        = local.kubeconfig_path
   kubeconfig_context     = local.kubeconfig_context
   registry_dockerio      = var.registry_dockerio
+
+  prometheus_crds_ready = var.enable_observability ? helm_release.prometheus_operator_crds[0].name : ""
 
   depends_on = [
     null_resource.k3d_cluster,
@@ -87,6 +106,8 @@ module "k8s_common" {
 
   enable_observability   = var.enable_observability
   observability_hostname = var.observability_hostname
+
+  gdcn_helm_extra_values = var.gdcn_helm_extra_values
 
   # Local SeaweedFS-backed S3 (used for CSV upload storage via Quiver datasource FS)
   local_s3_endpoint_override    = module.k8s_local.seaweedfs_s3_endpoint

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -165,6 +165,13 @@ variable "helm_kube_prometheus_stack_version" {
   default = "83.4.0"
 }
 
+variable "helm_prometheus_operator_crds_version" {
+  description = "Version of the prometheus-operator-crds Helm chart. Must match the prometheus-operator version bundled in helm_kube_prometheus_stack_version."
+  type        = string
+  # renovate: depName=prometheus-operator-crds registryUrl=https://prometheus-community.github.io/helm-charts
+  default = "27.0.1"
+}
+
 variable "helm_promtail_version" {
   description = "Version of the promtail Helm chart to deploy."
   type        = string
@@ -281,4 +288,10 @@ variable "tls_mode" {
     condition     = contains(["selfsigned"], var.tls_mode)
     error_message = "tls_mode must be \"selfsigned\" for local installs."
   }
+}
+
+variable "gdcn_helm_extra_values" {
+  description = "Additional Helm values YAML string appended to the gooddata-cn chart values. Use to override sub-chart settings not exposed as Terraform variables."
+  type        = string
+  default     = ""
 }

--- a/modules/k8s-common/dashboards/gooddata-cn-overall-health.json
+++ b/modules/k8s-common/dashboards/gooddata-cn-overall-health.json
@@ -2620,7 +2620,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "max by (pod) (\n  (redis_instance_info{cluster_name=\"$cluster\", namespace=~\"$ns\", role=\"slave\"} * 1)\n  or\n  (redis_instance_info{cluster_name=\"$cluster\", namespace=~\"$ns\", role=\"master\"} * 0)\n)",
+          "expr": "max by (pod) (\n  (redis_instance_info{cluster_name=~\"$cluster|\", namespace=~\"$ns\", role=\"slave\"} * 1)\n  or\n  (redis_instance_info{cluster_name=~\"$cluster|\", namespace=~\"$ns\", role=\"master\"} * 0)\n)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -4312,35 +4312,27 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "Mimir",
+          "selected": false,
+          "text": "GDMIMIR",
           "value": "GDMIMIR"
         },
-        "hide": 0,
-        "includeAll": false,
+        "hide": 2,
         "label": "Prometheus",
-        "multi": false,
         "name": "DS_PROMETHEUS",
-        "options": [],
-        "query": "prometheus",
-        "refresh": 1,
-        "type": "datasource"
+        "query": "GDMIMIR",
+        "type": "constant"
       },
       {
         "current": {
-          "selected": true,
-          "text": "GD Loki",
+          "selected": false,
+          "text": "GDLOKI",
           "value": "GDLOKI"
         },
-        "hide": 0,
-        "includeAll": false,
+        "hide": 2,
         "label": "Loki",
-        "multi": false,
         "name": "DS_LOKI",
-        "options": [],
-        "query": "loki",
-        "refresh": 1,
-        "type": "datasource"
+        "query": "GDLOKI",
+        "type": "constant"
       },
       {
         "current": {

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -173,13 +173,14 @@ resource "helm_release" "gooddata_cn" {
       s3_datasource_fs_bucket = var.local_s3_datasource_fs_bucket
       s3_quiver_cache_bucket  = var.local_s3_quiver_cache_bucket
     }) : null,
-    templatefile("${path.module}/templates/gdcn-size-${var.size_profile}.yaml.tftpl", {})
+    templatefile("${path.module}/templates/gdcn-size-${var.size_profile}.yaml.tftpl", {}),
+    var.gdcn_helm_extra_values != "" ? var.gdcn_helm_extra_values : null,
   ])
 
   # Wait until all resources are ready before Terraform continues
   wait          = true
   wait_for_jobs = true
-  timeout       = 1800
+  timeout       = 3600
 
   depends_on = [
     kubernetes_namespace_v1.gdcn,
@@ -189,6 +190,51 @@ resource "helm_release" "gooddata_cn" {
     kubectl_manifest.selfsigned_cluster_issuer,
     helm_release.istio_ingress_gateway,
     kubectl_manifest.istio_public_gateway,
+    helm_release.kube_prometheus_stack,
+  ]
+}
+
+# PodMonitor for Redis HA exporter sidecar.
+# The redis-ha subchart does not create a PodMonitor, so we add one
+# to scrape the redis_exporter metrics (port 9121) into Prometheus.
+resource "kubectl_manifest" "redis_ha_podmonitor" {
+  count = var.enable_observability ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PodMonitor"
+    metadata = {
+      name      = "gooddata-cn-redis-ha"
+      namespace = var.gdcn_namespace
+      labels = {
+        "app.kubernetes.io/instance" = "gooddata-cn"
+        "app.kubernetes.io/name"     = "redis-ha"
+      }
+    }
+    spec = {
+      jobLabel = "gooddata-cn"
+      namespaceSelector = {
+        matchNames = [var.gdcn_namespace]
+      }
+      podMetricsEndpoints = [
+        {
+          interval      = "20s"
+          port          = "exporter-port"
+          path          = "/metrics"
+          scrapeTimeout = "10s"
+        }
+      ]
+      selector = {
+        matchLabels = {
+          app     = "redis-ha"
+          release = "gooddata-cn"
+        }
+      }
+    }
+  })
+
+  depends_on = [
+    helm_release.gooddata_cn,
     helm_release.kube_prometheus_stack,
   ]
 }

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -366,6 +366,14 @@ resource "helm_release" "grafana" {
               uid       = "prometheus"
               url       = "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090"
               access    = "proxy"
+              isDefault = false
+            },
+            {
+              name      = "Mimir"
+              type      = "prometheus"
+              uid       = "GDMIMIR"
+              url       = "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090"
+              access    = "proxy"
               isDefault = true
             },
             {
@@ -374,6 +382,14 @@ resource "helm_release" "grafana" {
               uid    = "loki"
               url    = "http://loki.observability.svc.cluster.local:3100"
               access = "proxy"
+            },
+            {
+              name      = "GD Loki"
+              type      = "loki"
+              uid       = "GDLOKI"
+              url       = "http://loki.observability.svc.cluster.local:3100"
+              access    = "proxy"
+              isDefault = false
             },
             {
               name   = "Tempo"
@@ -386,7 +402,7 @@ resource "helm_release" "grafana" {
                   enabled = true
                 }
                 tracesToLogsV2 = {
-                  datasourceUid = "loki"
+                  datasourceUid = "GDLOKI"
                 }
                 streamingEnabled = {
                   search = false

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -246,3 +246,9 @@ variable "starrocks_irsa_role_arn" {
 }
 
 variable "tls_mode" { type = string }
+
+variable "gdcn_helm_extra_values" {
+  description = "Additional Helm values YAML string appended to the gooddata-cn chart values. Use to override sub-chart settings not exposed as Terraform variables."
+  type        = string
+  default     = ""
+}

--- a/modules/k8s-local/postgres.tf
+++ b/modules/k8s-local/postgres.tf
@@ -31,6 +31,10 @@ resource "helm_release" "cnpg" {
   wait_for_jobs    = true
   timeout          = 600
 
+  values = var.enable_observability && var.prometheus_crds_ready != "" ? [yamlencode({
+    monitoring = { podMonitorEnabled = true }
+  })] : []
+
   depends_on = [
     kubernetes_namespace_v1.cnpg,
   ]
@@ -90,6 +94,10 @@ resource "kubectl_manifest" "postgres_cluster" {
           cpu    = "200m"
           memory = "256Mi"
         }
+      }
+
+      monitoring = {
+        enablePodMonitor = var.enable_observability
       }
 
       postgresql = {

--- a/modules/k8s-local/seaweedfs.tf
+++ b/modules/k8s-local/seaweedfs.tf
@@ -93,11 +93,11 @@ resource "helm_release" "seaweedfs" {
         resources = {
           requests = {
             cpu    = "100m"
-            memory = "256Mi"
+            memory = "512Mi"
           }
           limits = {
             cpu    = "500m"
-            memory = "512Mi"
+            memory = "1536Mi"
           }
         }
       }

--- a/modules/k8s-local/variables.tf
+++ b/modules/k8s-local/variables.tf
@@ -15,6 +15,18 @@ variable "enable_istio_injection" {
   default     = false
 }
 
+variable "enable_observability" {
+  description = "Whether observability (Prometheus, Grafana, etc.) is enabled. Controls PodMonitor creation for CNPG and PostgreSQL."
+  type        = bool
+  default     = false
+}
+
+variable "prometheus_crds_ready" {
+  description = "Name of the prometheus-operator-crds helm release. When non-empty, CNPG operator PodMonitor is enabled. Used as a dependency hint to ensure CRDs exist before CNPG applies them."
+  type        = string
+  default     = ""
+}
+
 variable "helm_cnpg_version" {
   description = "Version of the CloudNativePG Helm chart to deploy."
   type        = string


### PR DESCRIPTION
## Summary

   - Add **Mimir** (`GDMIMIR`) and **GD Loki** (`GDLOKI`) Grafana datasources with stable UIDs for dashboard portability across environments; fix duplicate
    `isDefault` provisioning error
   - Add **Redis HA PodMonitor** to scrape `redis_exporter` metrics (port 9121) into Prometheus — the redis-ha subchart doesn't create one
   - Update **GoodData CN Overall Health** dashboard: convert datasource dropdowns to hidden constant variables, add dedicated Redis section (4b) with
   Replica Status panel, renumber subsequent sections
   - Add `gdcn_helm_extra_values` variable for sub-chart overrides (e.g. redis-ha image/replica customization)
   - Enable CNPG operator and PostgreSQL cluster PodMonitors when observability is enabled
   - Install `prometheus-operator-crds` as a separate Helm release to ensure CRDs exist before CNPG PodMonitors are created
   - Increase SeaweedFS filer memory limits for stability under load

   ## Test plan

   - [x] Deployed to local k3d cluster with `terraform apply`
   - [x] Verified Grafana starts without datasource provisioning errors
   - [x] Verified Redis PodMonitor targets show as `up` in Prometheus (`redis_instance_info` metric available)
   - [x] Verified Redis Replica Status panel renders in Grafana dashboard (handles missing `cluster_name` label)
   - [x] Verified all GoodData CN pods healthy after upgrade to 3.58.0
   - [x] Validate `terraform plan` passes in aws and azure directories

   🤖 Generated with [Claude Code](https://claude.com/claude-code)
   
   JIRA: INFRA-4442