### PR TITLE
fix(azure): order ACR plumbing after k8s_common on destroy

### DIFF
--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -61,6 +61,15 @@ module "k8s_common" {
     azurerm_kubernetes_cluster.main,
     azurerm_role_assignment.gdcn_blob_contrib,
     azurerm_federated_identity_credential.gdcn,
+    # Image cache plumbing must outlive the helm releases: pre-delete hooks
+    # pull images via the cache rules, and kubelet needs AcrPull. Listing
+    # these here makes destroy tear down k8s_common first, ACR plumbing after.
+    azurerm_container_registry_cache_rule.dockerio,
+    azurerm_container_registry_cache_rule.quayio,
+    azurerm_container_registry_cache_rule.k8sio,
+    azurerm_container_registry_credential_set.dockerio,
+    azurerm_role_assignment.aks_acr_pull,
+    azurerm_role_assignment.acr_credential_set_secrets_user,
   ]
 }
 


### PR DESCRIPTION
## Summary
- Add the ACR cache rules, the `dockerio` credential set, and the AKS/credential-set role assignments to `module.k8s_common.depends_on`.
- On destroy this forces Terraform to tear down the helm releases first, so pre-delete hooks can still pull images through the cache rules and kubelet still has `AcrPull` while pods are draining.

## Test plan
- [x] `terraform fmt -recursive` is clean
- [x] `cd azure && terraform validate`
- [ ] `cd azure && terraform plan -var-file=settings.tfvars` shows only `depends_on` metadata changes on `module.k8s_common` (no resource replacements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)