### PR TITLE
fix(observability): set tempo registry under image.registry

### DIFF
--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -212,7 +212,7 @@ resource "helm_release" "tempo" {
   values = [
     yamlencode({
       tempo = {
-        registry = var.registry_dockerio
+        image = { registry = var.registry_dockerio }
         receivers = {
           jaeger = {
             protocols = {


### PR DESCRIPTION
## Summary
- Move `tempo.registry` to `tempo.image.registry` to match the current Tempo helm chart schema; the previous key is ignored and Tempo pulls from docker.io directly.

## Test plan
- [x] `terraform fmt -recursive` is clean
- [x] `terraform validate` in `aws/`, `azure/`, and `local/`
- [ ] `terraform plan -var-file=settings.tfvars` in each env shows only an in-place update to `helm_release.tempo` values
- [ ] After apply, `kubectl -n observability get pods -l app.kubernetes.io/name=tempo -o jsonpath='{.items[*].spec.containers[*].image}'` shows the image pulled from `var.registry_dockerio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)