### PR TITLE
fix(observability): opt out of distroless images for kube-prometheus-stack v85

### DIFF
--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -56,9 +56,7 @@ resource "helm_release" "kube_prometheus_stack" {
 
       prometheus = {
         prometheusSpec = {
-          # tag pinned to non-distroless: v85 defaults to v3.11.3-distroless;
-          # private registry mirror does not carry distroless-tagged variants.
-          image = { registry = var.registry_quayio, tag = "v3.11.3" }
+          image = { registry = var.registry_quayio }
           externalLabels = {
             cluster_name = var.deployment_name
           }

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -33,7 +33,9 @@ resource "helm_release" "kube_prometheus_stack" {
         image = { registry = var.registry_k8sio }
       }
       "prometheus-node-exporter" = {
-        image = { registry = var.registry_quayio }
+        # distroless=false: v85 enables distroless by default; private registry
+        # mirror does not carry distroless-tagged variants.
+        image = { registry = var.registry_quayio, distroless = false }
       }
 
       prometheusOperator = {
@@ -54,7 +56,9 @@ resource "helm_release" "kube_prometheus_stack" {
 
       prometheus = {
         prometheusSpec = {
-          image = { registry = var.registry_quayio }
+          # tag pinned to non-distroless: v85 defaults to v3.11.3-distroless;
+          # private registry mirror does not carry distroless-tagged variants.
+          image = { registry = var.registry_quayio, tag = "v3.11.3" }
           externalLabels = {
             cluster_name = var.deployment_name
           }


### PR DESCRIPTION
## Problem

kube-prometheus-stack v85 ([#148](https://github.com/gooddata/gooddata-cn-terraform/pull/148)) enables distroless image variants by default for both `prometheus` (`v3.11.3-distroless`) and `prometheus-node-exporter`. The private registry mirrors (`var.registry_quayio`) do not carry distroless-tagged images — applying v85 without this fix would cause image pull failures.

From the chart's [UPGRADE.md](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-85.0.1/charts/kube-prometheus-stack/UPGRADE.md):
> *This version enables the `distroless` variant of both the `prometheus` and `prometheus-node-exporter` images by default. If you sync images to your private registry, ensure that you also sync image tags with the distroless suffix.*

## Fix

- `prometheus-node-exporter`: add `distroless = false` to image override
- `prometheus`: pin `tag = "v3.11.3"` (non-distroless) to image override

## Merge order

Merge this PR **before** merging [#148](https://github.com/gooddata/gooddata-cn-terraform/pull/148).