### PR TITLE
feat(ai): enable agentic conversations and GenAI memory

### DIFF
--- a/modules/k8s-common/templates/gdcn-ai-features.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-ai-features.yaml.tftpl
@@ -5,3 +5,5 @@ enableGenAIChat: true
 deployGenAIMetadataSync: true
 deployQdrant: true
 deployMCPServer: true
+enableAiAgenticConversations: true
+enableGenAIMemory: true


### PR DESCRIPTION
## Summary
- Enable `enableAiAgenticConversations` and `enableGenAIMemory` in the shared `gdcn-ai-features.yaml.tftpl` template.

JIRA: TRIVIAL
risk: low