### PR TITLE
fix(local): keep prometheus-operator-crds installed when observability is disabled

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -155,11 +155,11 @@ module "eks" {
         tags = merge(
           local.common_tags,
           {
-            "k8s.io/cluster-autoscaler/enabled"                                       = "true"
-            "k8s.io/cluster-autoscaler/${var.deployment_name}"                        = "owned"
-            "k8s.io/cluster-autoscaler/node-template/label/workload"                  = "starrocks"
+            "k8s.io/cluster-autoscaler/enabled"                                         = "true"
+            "k8s.io/cluster-autoscaler/${var.deployment_name}"                          = "owned"
+            "k8s.io/cluster-autoscaler/node-template/label/workload"                    = "starrocks"
             "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/zone" = ng.az
-            "k8s.io/cluster-autoscaler/node-template/taint/workload"                  = "starrocks:NoSchedule"
+            "k8s.io/cluster-autoscaler/node-template/taint/workload"                    = "starrocks:NoSchedule"
           }
         )
 

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -37,12 +37,6 @@ resource "helm_release" "prometheus_operator_crds" {
   depends_on = [null_resource.k3d_cluster]
 }
 
-# The release used to be conditional on enable_observability (count-indexed).
-moved {
-  from = helm_release.prometheus_operator_crds[0]
-  to   = helm_release.prometheus_operator_crds
-}
-
 module "k8s_local" {
   source = "../modules/k8s-local"
 

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -20,9 +20,9 @@ resource "random_password" "local_postgres_password" {
   override_special = "_-"
 }
 
+# Always installed: deleting these CRDs while installed releases still
+# reference ServiceMonitor/PodMonitor objects breaks helm upgrades.
 resource "helm_release" "prometheus_operator_crds" {
-  count = var.enable_observability ? 1 : 0
-
   name             = "prometheus-operator-crds"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "prometheus-operator-crds"
@@ -35,6 +35,12 @@ resource "helm_release" "prometheus_operator_crds" {
   timeout = 300
 
   depends_on = [null_resource.k3d_cluster]
+}
+
+# The release used to be conditional on enable_observability (count-indexed).
+moved {
+  from = helm_release.prometheus_operator_crds[0]
+  to   = helm_release.prometheus_operator_crds
 }
 
 module "k8s_local" {
@@ -56,7 +62,7 @@ module "k8s_local" {
   kubeconfig_context     = local.kubeconfig_context
   registry_dockerio      = var.registry_dockerio
 
-  prometheus_crds_ready = var.enable_observability ? helm_release.prometheus_operator_crds[0].name : ""
+  prometheus_crds_ready = helm_release.prometheus_operator_crds.name
 
   depends_on = [
     null_resource.k3d_cluster,


### PR DESCRIPTION
## Problem

Disabling `enable_observability` on a cluster where it was previously enabled fails every subsequent `terraform apply`:

```
Upgrade failed: unable to build kubernetes objects from current release manifest:
resource mapping not found for name: "cert-manager" ... no matches for kind
"ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
```

The local env installs `prometheus-operator-crds` as a count-gated release. Disabling observability destroys it, deleting the ServiceMonitor/PodMonitor CRDs — while the installed manifests of cert-manager, ingress-nginx, and pulsar still contain those kinds, so Helm can't even parse the current release to upgrade it.

AWS/Azure don't hit this because kube-prometheus-stack's bundled CRDs survive `helm uninstall` by design.

## Fix

- Install `prometheus-operator-crds` unconditionally in the local env (the CRDs are tiny and harmless when unused), matching the CRDs-persist semantics of AWS/Azure.
- Add a `moved` block so clusters with the count-indexed release in state migrate cleanly.
- Simplify `prometheus_crds_ready` wiring accordingly.
- Also picks up pre-existing `terraform fmt` drift in `aws/eks.tf`.

## Verification

- `terraform fmt -recursive` clean; `terraform validate` passes in all three envs (local/aws/azure).
- Ran `terraform plan` against a copy of the live broken state: succeeds with `2 to add, 5 to change, 0 to destroy` — CRDs are reinstalled first (transitive dependency via `module.k8s_local`), then the three stuck releases upgrade in-place and drop their monitors. This also recovers clusters already stuck in the failed-disable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)