### PR TITLE
chore: gitignore Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ terraform.rc
 
 # Local k3d generated config (created by terraform apply)
 local/k3d-config.generated.yaml
+
+# Claude Code local state
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
Adds Claude Code local state to `.gitignore`:

- `.claude/worktrees/` — per-session git worktrees
- `.claude/settings.local.json` — local user settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)