### PR TITLE
feat(ai): add enable_experimental_features flag

### DIFF
--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -59,11 +59,12 @@ module "k8s_common" {
   tls_mode                = var.tls_mode
   ingress_nginx_behind_l7 = var.ingress_nginx_behind_l7
 
-  enable_ai_features = var.enable_ai_features
-  enable_image_cache = var.enable_image_cache
-  registry_dockerio  = local.registry_dockerio
-  registry_quayio    = local.registry_quayio
-  registry_k8sio     = local.registry_k8sio
+  enable_ai_features           = var.enable_ai_features
+  enable_experimental_features = var.enable_experimental_features
+  enable_image_cache           = var.enable_image_cache
+  registry_dockerio            = local.registry_dockerio
+  registry_quayio              = local.registry_quayio
+  registry_k8sio               = local.registry_k8sio
 
   helm_cert_manager_version          = var.helm_cert_manager_version
   helm_gdcn_version                  = var.helm_gdcn_version

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -29,6 +29,9 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 # Deploys and enables GoodData generative AI services
 # enable_ai_features = true
 
+# Enable experimental AI features (subject to change; the set of features may evolve over time)
+# enable_experimental_features = true
+
 # Size profile controls replicas/resources across services:
 # - dev: lowest footprint, not HA
 # - prod-small: HA (>= 2 replica per service), resources for services increased

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -118,6 +118,12 @@ variable "enable_ai_features" {
   default     = true
 }
 
+variable "enable_experimental_features" {
+  description = "Enable experimental AI features in the gooddata-cn chart. These are subject to change and the set of features may evolve over time."
+  type        = bool
+  default     = false
+}
+
 variable "enable_image_cache" {
   description = "Enable image caching (ECR pull-through cache). If false, images are pulled from upstream registries directly."
   type        = bool

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -27,11 +27,12 @@ module "k8s_common" {
   tls_mode                = var.tls_mode
   ingress_nginx_behind_l7 = var.ingress_nginx_behind_l7
 
-  enable_ai_features = var.enable_ai_features
-  enable_image_cache = var.enable_image_cache
-  registry_dockerio  = local.registry_dockerio
-  registry_quayio    = local.registry_quayio
-  registry_k8sio     = local.registry_k8sio
+  enable_ai_features           = var.enable_ai_features
+  enable_experimental_features = var.enable_experimental_features
+  enable_image_cache           = var.enable_image_cache
+  registry_dockerio            = local.registry_dockerio
+  registry_quayio              = local.registry_quayio
+  registry_k8sio               = local.registry_k8sio
 
   helm_cert_manager_version          = var.helm_cert_manager_version
   helm_gdcn_version                  = var.helm_gdcn_version

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -26,6 +26,9 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 # Deploys and enables GoodData generative AI services
 # enable_ai_features = true
 
+# Enable experimental AI features (subject to change; the set of features may evolve over time)
+# enable_experimental_features = true
+
 # Size profile controls replicas/resources across services:
 # - dev: lowest footprint, not HA
 # - prod-small: HA (>= 2 replica per service), resources for services increased

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -110,6 +110,12 @@ variable "enable_ai_features" {
   default     = true
 }
 
+variable "enable_experimental_features" {
+  description = "Enable experimental AI features in the gooddata-cn chart. These are subject to change and the set of features may evolve over time."
+  type        = bool
+  default     = false
+}
+
 variable "enable_image_cache" {
   description = "Enable image caching (ACR pull-through cache). If false, images are pulled from upstream registries directly."
   type        = bool

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -88,11 +88,12 @@ module "k8s_common" {
   tls_mode                = var.tls_mode
   ingress_nginx_behind_l7 = var.ingress_nginx_behind_l7
 
-  enable_ai_features = var.enable_ai_features
-  enable_image_cache = false
-  registry_dockerio  = var.registry_dockerio
-  registry_quayio    = var.registry_quayio
-  registry_k8sio     = var.registry_k8sio
+  enable_ai_features           = var.enable_ai_features
+  enable_experimental_features = var.enable_experimental_features
+  enable_image_cache           = false
+  registry_dockerio            = var.registry_dockerio
+  registry_quayio              = var.registry_quayio
+  registry_k8sio               = var.registry_k8sio
 
   helm_cert_manager_version          = var.helm_cert_manager_version
   helm_gdcn_version                  = var.helm_gdcn_version

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -25,6 +25,9 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 # Deploys and enables GoodData generative AI services
 # enable_ai_features = true
 
+# Enable experimental AI features (subject to change; the set of features may evolve over time)
+# enable_experimental_features = true
+
 # Size profile controls replicas/resources across services:
 # - dev: lowest footprint, not HA
 # NOTE: switching size profile after deploying isn't supported since persistent

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -38,6 +38,12 @@ variable "enable_ai_features" {
   default     = true
 }
 
+variable "enable_experimental_features" {
+  description = "Enable experimental AI features in the gooddata-cn chart. These are subject to change and the set of features may evolve over time."
+  type        = bool
+  default     = false
+}
+
 variable "enable_observability" {
   description = "Enable observability stack (Prometheus, Loki, Tempo, Grafana)"
   type        = bool

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -140,7 +140,9 @@ resource "helm_release" "gooddata_cn" {
     local.use_istio_gateway ? templatefile("${path.module}/templates/gdcn-istio.yaml.tftpl", {
       existing_gateway = "istio-ingress/${local.istio_public_gateway_name}"
     }) : null,
-    var.enable_ai_features ? templatefile("${path.module}/templates/gdcn-ai-features.yaml.tftpl", {}) : null,
+    var.enable_ai_features ? templatefile("${path.module}/templates/gdcn-ai-features.yaml.tftpl", {
+      enable_experimental_features = var.enable_experimental_features
+    }) : null,
     var.enable_image_cache ? templatefile("${path.module}/templates/gdcn-image-cache.yaml.tftpl", {
       registry_dockerio = var.registry_dockerio,
       registry_quayio   = var.registry_quayio

--- a/modules/k8s-common/templates/gdcn-ai-features.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-ai-features.yaml.tftpl
@@ -7,3 +7,29 @@ deployQdrant: true
 deployMCPServer: true
 enableAiAgenticConversations: true
 enableGenAIMemory: true
+
+%{ if enable_experimental_features ~}
+# Enable experimental features
+enableAiHub: true
+enableGenAiMetricSkill: true
+enableGenAiVisualizationSummarySkill: true
+enableGenAiDashboardSummarySkill: true
+enableGenAiHeadlessSummary: true
+enableGenAiKdaSkill: true
+enableGenAiWhatifSkill: true
+enableGenAiAlertSkill: true
+enableGenAiVisualizationSkill: true
+enableGenAiForecastingSkill: true
+enableGenAiAnomalySkill: true
+enableGenAiClusteringSkill: true
+enableGenAiMemoryAgent: true
+enableAIKnowledge: true
+enableScheduledExportSkill: true
+enableGenAiAgentSwitching: true
+enableGenAIPromptRedesign: true
+enableMultilingualAIAssistant: true
+enableGenAIReasoningVisibility: true
+enableGenAiAiModuleGating: true
+enableGenAiAlerts: true
+enableAIDataSetting: true
+%{ endif ~}

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -50,6 +50,8 @@ variable "dex_ingress_annotations_override" {
 
 variable "enable_ai_features" { type = bool }
 
+variable "enable_experimental_features" { type = bool }
+
 variable "enable_image_cache" { type = bool }
 
 variable "enable_observability" {


### PR DESCRIPTION
## What

Adds an opt-in `enable_experimental_features` variable (default `false`) that gates a set of **experimental** GenAI skills/features in the gooddata-cn chart.

When enabled, `gdcn-ai-features.yaml.tftpl` emits the experimental feature toggles (AI Hub, GenAI metric/visualization/dashboard/KDA/what-if/alert/forecasting/anomaly/clustering skills, memory agent, AI knowledge, scheduled export, agent switching, prompt redesign, multilingual assistant, reasoning visibility, etc.).

## Where

- `modules/k8s-common`: new `enable_experimental_features` variable, passed into the AI features values template.
- `aws` / `azure` / `local`: new variable (default `false`), wired into the `k8s_common` module, plus a commented example in each `settings.tfvars.example`.

## Behavior

No change unless explicitly set to `true`. These features are subject to change and the set may evolve over time.