### PR TITLE
feat(sizing): add prod-large size profile

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -32,6 +32,7 @@ locals {
   eks_node_type_presets = {
     dev        = ["m6a.xlarge", "m6a.2xlarge"]
     prod-small = ["m8a.xlarge", "m8a.2xlarge"]
+    prod-large = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
     prod-xl    = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
   }
 
@@ -41,8 +42,12 @@ locals {
     prod-xl    = ["r8a.large", "r8a.8xlarge"]
   }
 
+  # There is no dedicated prod-large StarRocks profile; fall back to prod-xl
+  # StarRocks sizing when size_profile is prod-large (see gdcn-size-prod-large).
+  starrocks_size_profile_effective = coalesce(var.starrocks_size_profile, var.size_profile == "prod-large" ? "prod-xl" : var.size_profile)
+
   eks_node_types           = coalesce(var.eks_node_types, local.eks_node_type_presets[var.size_profile])
-  eks_starrocks_node_types = coalesce(var.eks_starrocks_node_types, local.eks_starrocks_node_type_presets[coalesce(var.starrocks_size_profile, var.size_profile)])
+  eks_starrocks_node_types = coalesce(var.eks_starrocks_node_types, local.eks_starrocks_node_type_presets[local.starrocks_size_profile_effective])
 
   # Per-AZ node groups for StarRocks so the cluster autoscaler can scale
   # nodes in the AZ where the FE/CN EBS volume lives (EBS is zonal).
@@ -155,11 +160,11 @@ module "eks" {
         tags = merge(
           local.common_tags,
           {
-            "k8s.io/cluster-autoscaler/enabled"                                       = "true"
-            "k8s.io/cluster-autoscaler/${var.deployment_name}"                        = "owned"
-            "k8s.io/cluster-autoscaler/node-template/label/workload"                  = "starrocks"
+            "k8s.io/cluster-autoscaler/enabled"                                         = "true"
+            "k8s.io/cluster-autoscaler/${var.deployment_name}"                          = "owned"
+            "k8s.io/cluster-autoscaler/node-template/label/workload"                    = "starrocks"
             "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/zone" = ng.az
-            "k8s.io/cluster-autoscaler/node-template/taint/workload"                  = "starrocks:NoSchedule"
+            "k8s.io/cluster-autoscaler/node-template/taint/workload"                    = "starrocks:NoSchedule"
           }
         )
 

--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -49,7 +49,7 @@ module "k8s_common" {
   gdcn_license_key       = var.gdcn_license_key
   gdcn_orgs              = var.gdcn_orgs
   size_profile           = var.size_profile
-  starrocks_size_profile = coalesce(var.starrocks_size_profile, var.size_profile)
+  starrocks_size_profile = local.starrocks_size_profile_effective
   cloud                  = "aws"
   ingress_controller     = var.ingress_controller
   gdcn_irsa_role_arn     = aws_iam_role.gdcn_irsa.arn

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -32,6 +32,8 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 # Size profile controls replicas/resources across services:
 # - dev: lowest footprint, not HA
 # - prod-small: HA (>= 2 replica per service), resources for services increased
+# - prod-large: HA, sized for large/high-traffic deployments (more replicas +
+#   CPU/memory for the hot-path services than prod-small)
 # NOTE: switching size profile after deploying isn't supported since persistent
 # volume sizes can't be automatically adjusted in-place.
 size_profile = "prod-small"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -419,8 +419,8 @@ variable "size_profile" {
   type        = string
   default     = "prod-small"
   validation {
-    condition     = contains(["dev", "prod-small", "prod-xl"], var.size_profile)
-    error_message = "size_profile must be one of: dev, prod-small, prod-xl."
+    condition     = contains(["dev", "prod-small", "prod-xl", "prod-large"], var.size_profile)
+    error_message = "size_profile must be one of: dev, prod-small, prod-xl, prod-large."
   }
 }
 

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -13,12 +13,13 @@ module "k8s_common" {
     external   = external
   }
 
-  deployment_name        = var.deployment_name
-  gdcn_namespace         = var.gdcn_namespace
-  gdcn_license_key       = var.gdcn_license_key
-  gdcn_orgs              = var.gdcn_orgs
-  size_profile           = var.size_profile
-  starrocks_size_profile = var.size_profile
+  deployment_name  = var.deployment_name
+  gdcn_namespace   = var.gdcn_namespace
+  gdcn_license_key = var.gdcn_license_key
+  gdcn_orgs        = var.gdcn_orgs
+  size_profile     = var.size_profile
+  # There is no prod-large StarRocks profile; fall back to prod-xl sizing.
+  starrocks_size_profile = var.size_profile == "prod-large" ? "prod-xl" : var.size_profile
   cloud                  = "azure"
   ingress_controller     = var.ingress_controller
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -315,8 +315,8 @@ variable "size_profile" {
   type        = string
   default     = "prod-small"
   validation {
-    condition     = contains(["dev", "prod-small"], var.size_profile)
-    error_message = "size_profile must be one of: dev, prod-small."
+    condition     = contains(["dev", "prod-small", "prod-large"], var.size_profile)
+    error_message = "size_profile must be one of: dev, prod-small, prod-large."
   }
 }
 

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -74,12 +74,13 @@ module "k8s_common" {
     external   = external
   }
 
-  deployment_name        = var.deployment_name
-  gdcn_license_key       = var.gdcn_license_key
-  gdcn_namespace         = var.gdcn_namespace
-  gdcn_orgs              = var.gdcn_orgs
-  size_profile           = var.size_profile
-  starrocks_size_profile = coalesce(var.starrocks_size_profile, var.size_profile)
+  deployment_name  = var.deployment_name
+  gdcn_license_key = var.gdcn_license_key
+  gdcn_namespace   = var.gdcn_namespace
+  gdcn_orgs        = var.gdcn_orgs
+  size_profile     = var.size_profile
+  # There is no prod-large StarRocks profile; fall back to prod-xl sizing.
+  starrocks_size_profile = coalesce(var.starrocks_size_profile, var.size_profile == "prod-large" ? "prod-xl" : var.size_profile)
   cloud                  = "local"
   ingress_controller     = var.ingress_controller
 

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -275,8 +275,8 @@ variable "size_profile" {
   type        = string
   default     = "dev"
   validation {
-    condition     = contains(["dev"], var.size_profile)
-    error_message = "size_profile must be \"dev\" for local installs."
+    condition     = contains(["dev", "prod-large"], var.size_profile)
+    error_message = "size_profile must be one of: dev, prod-large."
   }
 }
 

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -275,8 +275,8 @@ variable "size_profile" {
   type        = string
   default     = "dev"
   validation {
-    condition     = contains(["dev", "prod-large"], var.size_profile)
-    error_message = "size_profile must be one of: dev, prod-large."
+    condition     = contains(["dev", "prod-small", "prod-large"], var.size_profile)
+    error_message = "size_profile must be one of: dev, prod-small, prod-large."
   }
 }
 

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -1,0 +1,437 @@
+# Apply GoodData.CN "prod-large" size profile
+# last updated: 2026-06-05
+#
+# Large production sizing profile, modeled on a high-traffic multi-tenant
+# GoodData.CN deployment. Compared to prod-small it runs more replicas of the
+# hot-path services (metadataApi, sqlExecutor, calcique, afmExecApi,
+# visualExporter, export-builder) and gives them substantially more CPU/memory,
+# enables dedicated Quiver policy nodes, and uses a larger result cache.
+#
+# NOTE on StarRocks (AI Lake): there is no prod-large StarRocks profile. When
+# size_profile = "prod-large" the StarRocks sizing falls back to prod-xl. Set
+# var.starrocks_size_profile explicitly if you want different StarRocks sizing.
+
+replicaCount: 2
+
+platform_limits:
+  max_column_size: 2000
+  max_dimension_size: 1000000
+  max_result_bytes: 500000000
+  max_result_cell_count: 50000000
+  # Double the limit of page size in AFM so that tabular-exporter can still
+  # load 1000 row pages even with the new 2000 column limit.
+  max_afm_result_page_bytes: 10485760
+  # Increase the export timeout to 7 minutes from the default 5: some exports can
+  # take as much as a little over 6 minutes to complete (XLSX most often).
+  export_result_timeout_seconds: 420
+
+# Deploy dedicated Quiver policy nodes so policy handling load is taken off the
+# cache nodes. Prevents hiccups during high load and/or releases.
+deployDedicatedPolicyNodes: true
+# Deploy the Quiver datasource filesystem nodes.
+deployQuiverDatasourceFs: true
+# Run the in-cluster GoodData etcd (paired with customEtcd.enabled below).
+useInternalGDEtcd: true
+
+afmExecApi:
+  jvmOptions: -Xmx1700M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=200M
+  replicaCount: 2
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 3100Mi
+    requests:
+      cpu: 200m
+      memory: 3100Mi
+analyticalDesigner:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 45Mi
+    requests:
+      cpu: 20m
+      memory: 15Mi
+apiDocs:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 45Mi
+    requests:
+      cpu: 20m
+      memory: 15Mi
+apiGateway:
+  jvmOptions: -Xmx225M -XX:MaxMetaspaceSize=128M -XX:MaxDirectMemorySize=512M
+  replicaCount: 2
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 1Gi
+authService:
+  jvmOptions: -Xmx256M -XX:MaxMetaspaceSize=160M -XX:MaxDirectMemorySize=32M
+  replicaCount: 2
+  resources:
+    limits:
+      cpu: 500m
+      memory: 820Mi
+    requests:
+      cpu: 100m
+      memory: 820Mi
+calcique:
+  jvmOptions: -Xmx1024M -XX:MaxMetaspaceSize=320M -XX:MaxDirectMemorySize=512M
+  replicaCount: 2
+  resources:
+    limits:
+      cpu: 1500m
+      memory: 2800Mi
+    requests:
+      cpu: 300m
+      memory: 2800Mi
+customEtcd:
+  enabled: true
+  resources:
+    requests:
+      cpu: 300m
+      memory: 1024Mi
+    limits:
+      cpu: 600m
+      memory: 1536Mi
+dashboards:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 45Mi
+    requests:
+      cpu: 20m
+      memory: 15Mi
+exportController:
+  jvmOptions: -Xmx1024M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=128M
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1792Mi
+    requests:
+      cpu: 250m
+      memory: 1024Mi
+# GenAI services (only deployed when AI features are enabled).
+# Safe to leave in place when AI features are off.
+genAiService:
+  fastembed:
+    metadata_sync_workers: 10
+  pulsar:
+    metadataSync:
+      max_consumer_concurrency: 100
+  resources:
+    limits:
+      cpu: 4000m
+      memory: 7168Mi
+    requests:
+      cpu: 2000m
+      memory: 5120Mi
+genAi:
+  resources:
+    limits:
+      cpu: 4000m
+      memory: 6144Mi
+    requests:
+      cpu: 2000m
+      memory: 3072Mi
+genAiMetadataSync:
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 6144Mi
+    requests:
+      cpu: 1500m
+      memory: 4096Mi
+homeUi:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 45Mi
+    requests:
+      cpu: 50m
+      memory: 15Mi
+ldmModeler:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 60Mi
+    requests:
+      cpu: 20m
+      memory: 15Mi
+measureEditor:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 45Mi
+    requests:
+      cpu: 20m
+      memory: 15Mi
+metadataApi:
+  jvmOptions: -Xmx6000M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=128M -XX:ActiveProcessorCount=6 -Dkotlinx.coroutines.io.parallelism=16
+  pulsar:
+    metadataSync:
+      messageTTL: 3600
+  replicaCount: 4
+  resources:
+    limits:
+      # metadataApi is the busiest service; give it generous CPU headroom.
+      cpu: 4150m
+      memory: 7300Mi
+    requests:
+      cpu: 1650m
+      memory: 7300Mi
+organizationController:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 384Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+pdfStaplerService:
+  jvmOptions: -Xmx800M -XX:MaxMetaspaceSize=128M -XX:MaxDirectMemorySize=32M
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1500Mi
+    requests:
+      cpu: 100m
+      memory: 1500Mi
+qdrant:
+  persistence:
+    size: 30Gi
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 6000Mi
+    requests:
+      cpu: 1000m
+      memory: 3500Mi
+quiver:
+  limitFlightCount: 90000
+  # Increase concurrent put requests to prevent issues with the
+  # collectLabelElements APIs under load.
+  concurrentPutRequests: 32
+  s3DurableStorage:
+    durableS3WritesInProgress: 32
+  storage:
+    # The server work dir stores the flight catalog (SQLite database); as the
+    # total flight limit grows the workdir must be large enough to hold it.
+    serverWorkDirSize: 512Mi
+    cache:
+      diskCacheSize: 25Gi
+      diskSize: 30Gi
+  replicaCount:
+    xtab: 4
+  resources:
+    cache:
+      limits:
+        cpu: 1500m
+        memory: 2048Mi
+        ephemeral-storage: 30Gi
+      requests:
+        cpu: 600m
+        memory: 2048Mi
+        ephemeral-storage: 30Gi
+    xtab:
+      limits:
+        cpu: 1500m
+        memory: 7680Mi
+      requests:
+        cpu: 750m
+        memory: 2560Mi
+    ml:
+      limits:
+        cpu: 700m
+        memory: 5120Mi
+      requests:
+        cpu: 400m
+        memory: 2560Mi
+    policy:
+      limits:
+        cpu: 2100m
+        memory: 768Mi
+      requests:
+        cpu: 600m
+        memory: 768Mi
+  extraEnvVarsCache:
+    - name: QUIVER_ETCD_NEW_EVENT_READER
+      value: "1"
+  extraEnvVarsDatasource:
+    - name: QUIVER_ETCD_NEW_EVENT_READER
+      value: "1"
+  extraEnvVarsMl:
+    - name: QUIVER_ETCD_NEW_EVENT_READER
+      value: "1"
+  extraEnvVarsPolicy:
+    - name: QUIVER_ETCD_NEW_EVENT_READER
+      value: "1"
+  extraEnvVarsXtab:
+    - name: QUIVER_ETCD_NEW_EVENT_READER
+      value: "1"
+redis-ha:
+  replicas: 3
+  configmapTest:
+    resources:
+      limits:
+        cpu: 50m
+        memory: 40Mi
+      requests:
+        cpu: 20m
+        memory: 40Mi
+  exporter:
+    resources:
+      limits:
+        cpu: 200m
+        memory: 20Mi
+      requests:
+        cpu: 30m
+        memory: 20Mi
+  redis:
+    config:
+      maxmemory: 7300m
+    resources:
+      limits:
+        cpu: 1500m
+        memory: 9125Mi
+      requests:
+        cpu: 700m
+        memory: 9125Mi
+  sentinel:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 35Mi
+      requests:
+        cpu: 50m
+        memory: 35Mi
+  splitBrainDetection:
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 30m
+      limits:
+        memory: 64Mi
+        cpu: 150m
+resultCache:
+  jvmOptions: -Xmx2100M -XX:MaxMetaspaceSize=384M -XX:MaxDirectMemorySize=384M
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 3200Mi
+    requests:
+      cpu: 500m
+      memory: 3200Mi
+  pulsar:
+    executionFinish:
+      # bump the number of execution finish messages the pod can handle at once
+      maxConcurrentMessages: 96
+  # Large total result-cache size limit (512 GiB).
+  totalCacheLimit: 549755813888
+scanModel:
+  jvmOptions: -Xmx220M -XX:MaxMetaspaceSize=160M -XX:MaxDirectMemorySize=32M
+  resources:
+    limits:
+      cpu: 500m
+      memory: 700Mi
+    requests:
+      cpu: 100m
+      memory: 700Mi
+sqlExecutor:
+  jvmOptions: -Xmx2048M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=256M
+    -XX:ActiveProcessorCount=6
+  replicaCount: 5
+  resources:
+    limits:
+      cpu: 1500m
+      memory: 4096Mi
+    requests:
+      # Lower CPU request packs more sqlExecutor replicas per node.
+      cpu: 500m
+      memory: 3700Mi
+tabularExporter:
+  resources:
+    limits:
+      cpu: 1500m
+      memory: 7500Mi
+    requests:
+      cpu: 1000m
+      memory: 7500Mi
+visualExporterChromium:
+  resources:
+    limits:
+      cpu: 1200m
+      memory: 4Gi
+    requests:
+      cpu: 200m
+      memory: 4Gi
+visualExporterProxy:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 300Mi
+    requests:
+      cpu: 100m
+      memory: 215Mi
+visualExporterService:
+  extraEnvVars:
+    - name: SERVER_TOMCAT_THREADS_MAX
+      value: "2"
+    - name: SERVER_TOMCAT_ACCEPTCOUNT
+      value: "500"
+  jvmOptions: -Xmx432M -XX:MaxMetaspaceSize=192M -XX:MaxDirectMemorySize=16M
+  replicaCount: 4
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1280Mi
+    requests:
+      cpu: 500m
+      memory: 640Mi
+webComponents:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 45Mi
+    requests:
+      cpu: 20m
+      memory: 15Mi
+exportBuilder:
+  replicaCount: 4
+  # Chromium in standalone container within export-builder pod
+  # export-builder connects to Chromium using Chrome DevTools Protocol (CDP)
+  playwright:
+    browser:
+      type: "cdp"
+  # These settings must be aligned with resource.limits.memory value
+  # The minimum memory limit in MeBiBytes is (codecachesize+Xmx+metaspace+175)*1.024
+  jvmOptions: -XX:ReservedCodeCacheSize=60M -Xmx1500M -XX:MaxMetaspaceSize=210M -XX:MaxDirectMemorySize=128M
+  resources:
+    limits:
+      cpu: 2000m
+      # Additional 500Mi for Chromium
+      memory: 2500Mi
+    requests:
+      cpu: 200m
+      memory: 550Mi
+apiGw:
+  database:
+    pool:
+      # Wider apiGw DB connection pool for higher concurrency.
+      maxSize: 32
+      minIdle: 4
+      maxAcquireTime: 30000
+  resources:
+    limits:
+      cpu: 1400m
+      memory: 3000Mi
+    requests:
+      cpu: 280m
+      memory: 3000Mi
+  # -- Custom JVM options
+  # These settings must be aligned with resource.limits.memory value
+  jvmOptions: "-Xms1500m -Xmx1500m -XX:ActiveProcessorCount=2 -XX:MaxDirectMemorySize=256m"

--- a/modules/k8s-common/templates/pulsar-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/pulsar-size-prod-large.yaml.tftpl
@@ -1,0 +1,59 @@
+# Apply Pulsar "prod-large" size profile
+# last updated: 2026-06-05
+#
+# Pulsar sizing for the large production profile. Replica counts stay at the
+# HA-minimum (odd numbers); Pulsar is a message bus and is not the primary
+# scaling bottleneck - it is scaled mainly by giving the bookies more memory
+# and larger journals/ledgers.
+
+autorecovery:
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 384Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+bookkeeper:
+  replicaCount: 3
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 300m
+      memory: 704Mi
+  volumes:
+    journal:
+      name: journal
+      size: 10Gi
+    ledgers:
+      name: ledgers
+      size: 10Gi
+broker:
+  replicaCount: 3
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1024Mi
+    requests:
+      cpu: 300m
+      memory: 512Mi
+  configData:
+    managedLedgerDefaultEnsembleSize: "3"
+    managedLedgerDefaultWriteQuorum: "2"
+    managedLedgerDefaultAckQuorum: "2"
+zookeeper:
+  replicaCount: 3
+  resources:
+    limits:
+      cpu: 200m
+      memory: 768Mi
+    requests:
+      cpu: 100m
+      memory: 384Mi
+  volumes:
+    data:
+      name: data
+      size: 5Gi


### PR DESCRIPTION
## What

Adds a new opt-in **`prod-large`** size profile for large / high-traffic deployments, sized above `prod-small` (more replicas + CPU/memory for the hot-path services).

## Changes

- **New size templates:** `gdcn-size-prod-large.yaml.tftpl` and `pulsar-size-prod-large.yaml.tftpl` (consumed by the existing `gdcn-size-${size_profile}` / `pulsar-size-${size_profile}` lookups in the module).
- **aws/eks.tf:** `prod-large` EKS node-type preset. StarRocks has no dedicated `prod-large` profile, so it falls back to **prod-xl** StarRocks sizing via a new `starrocks_size_profile_effective` local.
- **azure / local:** same `prod-large → prod-xl` StarRocks fallback.
- **Validation:** `size_profile` now accepts `prod-large` in all three envs.
- **Docs:** `settings.tfvars.example` documents the new profile.

## Behavior

Purely additive — existing `dev` / `prod-small` / `prod-xl` profiles are unchanged. Validated with `terraform validate` in aws, azure, and local.

> Drive-by: `terraform fmt` also realigned a pre-existing cluster-autoscaler tags block in `aws/eks.tf` that was not fmt-clean on master.