### PR TITLE
fix(ai-features): remove enableGenAiAiModuleGating feature flag

### DIFF
--- a/modules/k8s-common/templates/gdcn-ai-features.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-ai-features.yaml.tftpl
@@ -29,7 +29,6 @@ enableGenAiAgentSwitching: true
 enableGenAIPromptRedesign: true
 enableMultilingualAIAssistant: true
 enableGenAIReasoningVisibility: true
-enableGenAiAiModuleGating: true
 enableGenAiAlerts: true
 enableAIDataSetting: true
 %{ endif ~}


### PR DESCRIPTION
## Summary
- Removes the `enableGenAiAiModuleGating` parameter from the `gdcn-ai-features` template

## Test plan
- [ ] Verify the parameter is no longer rendered in the AI features config

🤖 Generated with [Claude Code](https://claude.com/claude-code)