### PR TITLE
fix(aws): block SSE-C and disable bucket keys on S3 buckets

### DIFF
--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -61,6 +61,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "buckets" {
   bucket   = each.value.id
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
@@ -117,6 +120,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "starrocks" {
   bucket = aws_s3_bucket.starrocks[0].id
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = false
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }


### PR DESCRIPTION
## What

Tightens the server-side encryption configuration on the AWS S3 buckets (both the main `buckets` set and the `starrocks` bucket):

- `blocked_encryption_types = ["SSE-C"]` — reject customer-provided-key (SSE-C) uploads.
- `bucket_key_enabled = false` — do not use S3 bucket keys.

AES256 SSE remains the only accepted encryption. Isolated change to `aws/s3.tf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)