### PR TITLE
feat: plumb gdcn_helm_extra_values through aws and azure

### DIFF
--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -48,6 +48,7 @@ module "k8s_common" {
   gdcn_namespace         = var.gdcn_namespace
   gdcn_license_key       = var.gdcn_license_key
   gdcn_orgs              = var.gdcn_orgs
+  gdcn_helm_extra_values = var.gdcn_helm_extra_values
   size_profile           = var.size_profile
   starrocks_size_profile = local.starrocks_size_profile_effective
   cloud                  = "aws"

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -26,6 +26,15 @@ deployment_name   = "gooddata-cn"
 # GoodData.CN license key
 gdcn_license_key = "key/asdf==" # provided by GoodData
 
+# Additional Helm values appended LAST to the gooddata-cn chart values, so these
+# override the templated defaults. Use to set chart/sub-chart options not exposed
+# as Terraform variables. Provide raw YAML as a string (heredoc recommended).
+# gdcn_helm_extra_values = <<-EOT
+#   service:
+#     someComponent:
+#       replicaCount: 3
+# EOT
+
 # Deploys and enables GoodData generative AI services
 # enable_ai_features = true
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -168,6 +168,12 @@ variable "existing_vpc_id" {
   default     = ""
 }
 
+variable "gdcn_helm_extra_values" {
+  description = "Additional Helm values YAML string appended to the gooddata-cn chart values. Use to override sub-chart settings not exposed as Terraform variables."
+  type        = string
+  default     = ""
+}
+
 variable "gdcn_license_key" {
   description = "GoodData.CN license key (provided by your GoodData contact)"
   type        = string

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -13,11 +13,12 @@ module "k8s_common" {
     external   = external
   }
 
-  deployment_name  = var.deployment_name
-  gdcn_namespace   = var.gdcn_namespace
-  gdcn_license_key = var.gdcn_license_key
-  gdcn_orgs        = var.gdcn_orgs
-  size_profile     = var.size_profile
+  deployment_name        = var.deployment_name
+  gdcn_namespace         = var.gdcn_namespace
+  gdcn_license_key       = var.gdcn_license_key
+  gdcn_orgs              = var.gdcn_orgs
+  gdcn_helm_extra_values = var.gdcn_helm_extra_values
+  size_profile           = var.size_profile
   # There is no prod-large StarRocks profile; fall back to prod-xl sizing.
   starrocks_size_profile = var.size_profile == "prod-large" ? "prod-xl" : var.size_profile
   cloud                  = "azure"

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -23,6 +23,15 @@ deployment_name   = "gooddata-cn"
 # GoodData.CN license key
 gdcn_license_key = "key/asdf==" # provided by GoodData
 
+# Additional Helm values appended LAST to the gooddata-cn chart values, so these
+# override the templated defaults. Use to set chart/sub-chart options not exposed
+# as Terraform variables. Provide raw YAML as a string (heredoc recommended).
+# gdcn_helm_extra_values = <<-EOT
+#   service:
+#     someComponent:
+#       replicaCount: 3
+# EOT
+
 # Deploys and enables GoodData generative AI services
 # enable_ai_features = true
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -128,6 +128,12 @@ variable "enable_observability" {
   default     = false
 }
 
+variable "gdcn_helm_extra_values" {
+  description = "Additional Helm values YAML string appended to the gooddata-cn chart values. Use to override sub-chart settings not exposed as Terraform variables."
+  type        = string
+  default     = ""
+}
+
 variable "gdcn_license_key" {
   description = "GoodData.CN license key (provided by your GoodData contact)"
   type        = string

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -22,6 +22,15 @@ helm_gdcn_version = "4.7.0" # use latest version here: https://www.gooddata.com/
 # GoodData.CN license key
 gdcn_license_key = "key/asdf==" # provided by GoodData
 
+# Additional Helm values appended LAST to the gooddata-cn chart values, so these
+# override the templated defaults. Use to set chart/sub-chart options not exposed
+# as Terraform variables. Provide raw YAML as a string (heredoc recommended).
+# gdcn_helm_extra_values = <<-EOT
+#   service:
+#     someComponent:
+#       replicaCount: 3
+# EOT
+
 # Deploys and enables GoodData generative AI services
 # enable_ai_features = true
 


### PR DESCRIPTION
## What

Brings the `aws` and `azure` environments to parity with `local` and the `k8s-common` module, which already support `gdcn_helm_extra_values` — a raw YAML string appended **last** to the gooddata-cn chart values, for overriding sub-chart settings not exposed as Terraform variables.

- `aws/variables.tf`, `azure/variables.tf` — add the `gdcn_helm_extra_values` variable (default `""`).
- `aws/k8s-common.tf`, `azure/k8s-common.tf` — pass it into the `k8s_common` module.
- `aws|azure|local/settings.tfvars.example` — documented commented example (heredoc).

`terraform validate` passes for both aws and azure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)