### PR TITLE
feat(observability): configurable telemetry retention

### DIFF
--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -79,8 +79,11 @@ module "k8s_common" {
   helm_tempo_version                 = var.helm_tempo_version
   helm_grafana_version               = var.helm_grafana_version
 
-  enable_observability   = var.enable_observability
-  observability_hostname = var.observability_hostname
+  enable_observability        = var.enable_observability
+  observability_hostname      = var.observability_hostname
+  loki_retention_period       = var.loki_retention_period
+  prometheus_retention_period = var.prometheus_retention_period
+  tempo_retention_period      = var.tempo_retention_period
 
   enable_ai_lake                        = var.enable_ai_lake
   starrocks_s3_bucket_id                = var.enable_ai_lake ? aws_s3_bucket.starrocks[0].id : ""

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -123,6 +123,12 @@ gdcn_orgs = [
 # Uncomment to enable the observability stack
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
+#
+# Telemetry retention (optional; defaults shown). Each signal has its own 5Gi
+# PVC, so lower these to bound storage. Loki must be a multiple of 24h.
+# loki_retention_period       = "168h"
+# prometheus_retention_period = "168h"
+# tempo_retention_period      = "168h"
 
 ###
 # Container image caching (optional)

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -381,6 +381,24 @@ variable "letsencrypt_email" {
   }
 }
 
+variable "loki_retention_period" {
+  description = "Loki log retention period (Go duration; multiple of 24h, e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
+variable "prometheus_retention_period" {
+  description = "Prometheus metrics retention period (e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
+variable "tempo_retention_period" {
+  description = "Tempo trace retention period (Go duration, e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
 variable "observability_hostname" {
   description = "Hostname for Grafana"
   type        = string

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -47,8 +47,11 @@ module "k8s_common" {
   helm_tempo_version                 = var.helm_tempo_version
   helm_grafana_version               = var.helm_grafana_version
 
-  enable_observability   = var.enable_observability
-  observability_hostname = var.observability_hostname
+  enable_observability        = var.enable_observability
+  observability_hostname      = var.observability_hostname
+  loki_retention_period       = var.loki_retention_period
+  prometheus_retention_period = var.prometheus_retention_period
+  tempo_retention_period      = var.tempo_retention_period
 
   db_hostname = azurerm_postgresql_flexible_server.main.fqdn
   db_username = local.db_username

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -102,6 +102,12 @@ gdcn_orgs = [
 # Uncomment to enable the observability stack
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
+#
+# Telemetry retention (optional; defaults shown). Each signal has its own 5Gi
+# PVC, so lower these to bound storage. Loki must be a multiple of 24h.
+# loki_retention_period       = "168h"
+# prometheus_retention_period = "168h"
+# tempo_retention_period      = "168h"
 
 ###
 # Container image caching (optional)

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -299,6 +299,24 @@ variable "letsencrypt_email" {
   }
 }
 
+variable "loki_retention_period" {
+  description = "Loki log retention period (Go duration; multiple of 24h, e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
+variable "prometheus_retention_period" {
+  description = "Prometheus metrics retention period (e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
+variable "tempo_retention_period" {
+  description = "Tempo trace retention period (Go duration, e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
 variable "observability_hostname" {
   description = "Hostname for Grafana"
   type        = string

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -107,8 +107,11 @@ module "k8s_common" {
   helm_tempo_version                 = var.helm_tempo_version
   helm_grafana_version               = var.helm_grafana_version
 
-  enable_observability   = var.enable_observability
-  observability_hostname = var.observability_hostname
+  enable_observability        = var.enable_observability
+  observability_hostname      = var.observability_hostname
+  loki_retention_period       = var.loki_retention_period
+  prometheus_retention_period = var.prometheus_retention_period
+  tempo_retention_period      = var.tempo_retention_period
 
   gdcn_helm_extra_values = var.gdcn_helm_extra_values
 

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -88,6 +88,12 @@ gdcn_orgs = [
 # Uncomment to enable the observability stack
 # enable_observability = true
 # observability_hostname = "observability.localhost"
+#
+# Telemetry retention (optional; defaults shown). Each signal has its own 5Gi
+# PVC, so lower these to bound storage. Loki must be a multiple of 24h.
+# loki_retention_period       = "168h"
+# prometheus_retention_period = "168h"
+# tempo_retention_period      = "168h"
 
 ###
 # Container registry authentication

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -247,6 +247,24 @@ variable "kubeconfig_path" {
   default     = "~/.kube/config"
 }
 
+variable "loki_retention_period" {
+  description = "Loki log retention period (Go duration; multiple of 24h, e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
+variable "prometheus_retention_period" {
+  description = "Prometheus metrics retention period (e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
+variable "tempo_retention_period" {
+  description = "Tempo trace retention period (Go duration, e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
+}
+
 variable "observability_hostname" {
   description = "Hostname for Grafana"
   type        = string

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -58,7 +58,7 @@ resource "helm_release" "kube_prometheus_stack" {
           externalLabels = {
             cluster_name = var.deployment_name
           }
-          retention = "2d"
+          retention = var.prometheus_retention_period
           resources = {
             requests = { cpu = "100m", memory = "256Mi" }
             limits   = { cpu = "500m", memory = "1Gi" }
@@ -117,6 +117,16 @@ resource "helm_release" "loki" {
               period = "24h"
             }
           }]
+        }
+        # Retention is enforced by the compactor loop below. retention_period
+        # caps log age; the 5Gi PVC still caps total size, so at high log volume
+        # data may be evicted before this period is reached.
+        limits_config = {
+          retention_period = var.loki_retention_period
+        }
+        compactor = {
+          retention_enabled    = true
+          delete_request_store = "filesystem"
         }
         auth_enabled = false
       }
@@ -230,6 +240,9 @@ resource "helm_release" "tempo" {
           }
           zipkin = { endpoint = "0.0.0.0:9411" }
         }
+        # Trace retention enforced by the block-storage compactor. The 5Gi PVC
+        # still caps total size, so traces may be evicted before this period.
+        retention = var.tempo_retention_period
       }
       persistence = {
         enabled = true

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -207,6 +207,12 @@ variable "local_s3_secret_key" {
   sensitive   = true
 }
 
+variable "loki_retention_period" {
+  description = "Loki log retention period (Go duration; must be a multiple of 24h, e.g. 168h = 7 days). Enables the compactor retention loop."
+  type        = string
+  default     = "168h"
+}
+
 variable "observability_hostname" {
   description = "Hostname for Grafana"
   type        = string
@@ -216,6 +222,12 @@ variable "observability_hostname" {
     condition     = var.enable_observability ? length(trimspace(var.observability_hostname)) > 0 : true
     error_message = "observability_hostname must be provided when enable_observability is true."
   }
+}
+
+variable "prometheus_retention_period" {
+  description = "Prometheus metrics retention period (e.g. 168h = 7 days)."
+  type        = string
+  default     = "168h"
 }
 
 variable "registry_dockerio" { type = string }
@@ -283,6 +295,12 @@ variable "starrocks_fe_image_tag" {
 variable "starrocks_irsa_role_arn" {
   type    = string
   default = ""
+}
+
+variable "tempo_retention_period" {
+  description = "Tempo trace retention period (Go duration, e.g. 168h = 7 days). Sets the block-storage compactor retention."
+  type        = string
+  default     = "168h"
 }
 
 variable "tls_mode" { type = string }


### PR DESCRIPTION
## What

Adds three retention knobs (default `168h` / 7 days) and wires retention enforcement into the observability stack:

- New variables `loki_retention_period`, `prometheus_retention_period`, `tempo_retention_period` — in the `k8s-common` module and all three environments (`aws`/`azure`/`local`), plumbed through each `k8s-common.tf`.
- `observability.tf`:
  - Prometheus `retention` now uses `var.prometheus_retention_period` (was hardcoded `2d`).
  - Loki gains a `limits_config.retention_period` + a `compactor` block (`retention_enabled`, `delete_request_store = "filesystem"`) to actually enforce retention.
  - Tempo gains block-storage compactor `retention`.
- Documented in all three `settings.tfvars.example`.

`terraform validate` passes for the module (via `local`) and for `aws`/`azure`.

> **Stacked on #177** (`feat/helm-extra-values-aws-azure`). Base will retarget to `master` once #177 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)