### PR TITLE
docs(skills): add perf-investigation skill

### DIFF
--- a/.claude/skills/perf-investigation/SKILL.md
+++ b/.claude/skills/perf-investigation/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: perf-investigation
+description: Use when investigating a performance problem in a deployed GoodData.CN (or similar multi-service Kubernetes platform) from observability data — slow dashboard/report loads, high latency, throughput that collapses under load, a request "stuck" somewhere, or a specific slow trace. Triggers include a trace ID with "why is this taking so long", a time-bounded report ("loading was slow ~10 minutes ago"), p95/latency regressions, "stuck in <service>", or queues/backlogs building. Drives a systematic root-cause investigation with Grafana metrics, logs, and traces — finds the true bottleneck, proves it with evidence, and names the correct fix. Use it even when the user hasn't named a specific service.
+---
+
+# Performance investigation
+
+You are handed a symptom — a slow trace, or "X was slow at time T" — and asked
+why. This skill is the method for answering that **from observability data**,
+without guessing.
+
+The single most important idea: **the symptom is rarely where the cause is.** A
+queue piling up on service A usually means A is blocked waiting on a slow
+service B downstream. So resist the urge to "fix" the service the user named.
+Find where the wall-clock time actually goes, prove it, and only then act.
+
+## When to use
+
+- A trace is slow and you need to know why ("trace `abc123` took 13s").
+- A time-bounded slowness report ("dashboards were slow around 14:30").
+- A latency/throughput regression, a request "stuck" in a service, or a
+  Pulsar/queue/consumer backlog building under load.
+
+**Do not use** for: writing load tests (this is post-hoc diagnosis), pure
+front-end/browser performance with no backend traces, or a one-off "is the
+cluster up" health check.
+
+## Prerequisites
+
+You need read access to the observability stack — Grafana with Prometheus
+(metrics), Loki (logs), and Tempo (traces), typically via the Grafana MCP
+tools. Read-only `kubectl` helps for pod/limit context. You do **not** need to
+change anything to diagnose; treat the investigation as read-only until you
+have proof and a named fix.
+
+## The investigation loop
+
+Work this in order. Each step narrows the search; don't skip ahead to a fix.
+
+### 1. Pin the symptom precisely
+
+Get a concrete anchor before touching any tool:
+- A **trace ID**, or
+- A **time window** (start/end) and **what** was slow (which endpoint / user
+  action), and **how slow** (p95? a single 30s outlier?).
+
+**If the anchor is ambiguous, ask the user — don't guess.** Use the
+AskUserQuestion tool to nail down the things only they know before you spend the
+investigation on the wrong target. The questions worth asking are usually:
+
+- **When** exactly (timezone-explicit), and is this a **one-off outlier or a
+  sustained/recurring** slowdown? (A 30s tail and a 30s p95 are different
+  problems.)
+- **What** action/endpoint — which dashboard, report, or API call — and from
+  one user or many?
+- **How slow vs. normal**, and **is it still happening** now or already over?
+- Was there a **recent change** (deploy, config, data volume, new tenant) that
+  lines up with onset?
+
+Derive cheaply what the data can tell you — the load burst from the
+request-rate metric, the slow endpoint from a slow-span search. Ask the user
+only for what the data can't: which action they mean, whether it's chronic,
+what "slow" means to them, what changed. One round of questions up front beats
+analyzing the wrong window. Vague symptom → vague investigation.
+
+### 2. Reproduce the evidence — do not theorize first
+
+Pull the actual data for that anchor before forming any theory (query patterns
+in [references/grafana-queries.md](references/grafana-queries.md)):
+- If you have a trace ID: fetch and **decompose the trace** (step 4).
+- If you have a window: find the slow traces in it (by service + minimum
+  duration), and pull per-service latency plus queue/backlog metrics — including
+  the Pulsar **unacked**-message backlog, a frequent and non-obvious culprit:
+  work delivered to a consumer but never finished shows up in neither CPU nor
+  request rate, yet stalls everything waiting behind it.
+
+### 3. Map the request path (discover it, don't assume)
+
+You need the service dependency chain to reason about cause vs. victim. Derive
+it from the evidence rather than memory:
+- The trace itself is the dependency graph — parent/child spans across services
+  show who calls whom.
+- The gateway's routing config maps URL patterns → backend services.
+- Service-to-service calls show up as client spans and gRPC/HTTP metrics.
+
+Note which hops are synchronous (caller blocks) vs. asynchronous (queue/topic
+hand-off) — the bottleneck behaves very differently in each. A slow synchronous
+downstream shows up as **latency and held connections** on the caller; a slow
+async consumer shows up as a **topic backlog**, not caller latency.
+
+For the GoodData.CN request flow specifically — the gateway routing table (slow
+URL → which backend owns it) and the AFM execution chain annotated with where
+each bottleneck class tends to live (the forward pool, the cache hit/miss fork,
+the `sql.select` / `result.xtab` async hops, the cross-tab and result-fetch
+stages) — read [references/request-flow.md](references/request-flow.md). It's
+the fast way to know which service a slow endpoint implicates before you open a
+single trace. Still confirm against the live trace; the map orients you, the
+trace proves it.
+
+### 4. Localize: where does the wall-clock actually go?
+
+This is the heart of it. **Decompose the slow trace into a span timeline** —
+for each span, its start offset relative to the root and its duration. Then ask
+of the span that dominates the wall-clock:
+
+- Is the time **inside its own self-time** (a gap with no active children)? →
+  the service is either computing, or **blocked waiting** (on a lock, a
+  connection, a downstream response it hasn't received yet, or a queue slot).
+- Is the time **inside child spans**? → the cost is downstream; follow the
+  child. The named service is a **conduit**, not the cause.
+
+A decisive tell: a span lasting seconds whose actual unit of work (the compute
+you can find in logs) is milliseconds is **waiting**, not working. That rules
+out "needs a faster CPU" and points at a queue, a connection pool, or a
+downstream stall.
+
+For a time-window report without one trace, do the same with metrics: per-hop
+latency over the window tells you which hop's latency rose; the queue/backlog
+metrics tell you where work piled up.
+
+### 5. Classify the bottleneck (the signature table)
+
+Once you know *which* service/hop owns the time, classify *why* using its CPU,
+throttling, queue depth, and latency together. This table is the most reusable
+part of the skill:
+
+| What you observe | Most likely cause | Right lever | Wrong lever (won't help) |
+|---|---|---|---|
+| **Idle CPU + deep queue + high latency** | A hardcoded **concurrency constant** capping in-flight work | Raise the constant (often a buried env var / pool size) | Add CPU or replicas |
+| **High CPU / CFS-throttled** | Genuine compute/resource shortage | More CPU limit, or scale out | Raising pool sizes (makes contention worse) |
+| **Queue on X, but X idle and its span time is in a downstream child** | X is a **victim** of a slow downstream | Fix the downstream gate | Scaling X |
+| **Idle CPU, can't keep up, no constant left to raise** — e.g. many clients' timeouts all point at one peer node that itself has spare CPU | An **architectural ceiling**: single-threaded loop, hot shard owned by one node, or strict-consistency gate | Code/architecture change or upstream report | More CPU/replicas/pods |
+| **DB/connection-acquire waits, app threads idle** | Connection-pool / acquire-timeout limit | Raise pool size (and check the DB can take it) | App CPU/replicas |
+| **Burstable instance, latency cliff after minutes** | Exhausted CPU credits (cloud burstable tier) | Non-burstable instance class | More app-side tuning |
+
+The first row is common and the easiest to misread as a CPU/replica shortage.
+Small concurrency constants — thread-pool sizes, an HTTP client's per-route
+connection pool, a JDBC/Hikari pool, a worker/subprocess count, a coroutine
+dispatcher cap, a message-consumer prefetch — throttle a service that then sits
+at low CPU while requests queue. The instinct to "add pods" is usually wrong
+here; the fix is raising the number.
+
+### 6. Prove it before recommending a fix
+
+A plausible story is not a proven one. Confirm with at least one hard check:
+
+- **Trace decomposition** already localized the time; confirm the dominant
+  span's time is self vs. child as you claimed.
+- **Little's law** turns queue depth into effective concurrency:
+  `L = λ × W` → effective concurrency `= throughput × mean-in-service-time`.
+  If that sits at a stable integer ceiling well below CPU saturation, that
+  ceiling is almost certainly a configured limit — then go find which one.
+- **Read the source / config defaults.** When a constant is opaque, the
+  container image is often public — pull it and read the real default and its
+  env-var override instead of guessing (commands in
+  [references/grafana-queries.md](references/grafana-queries.md)).
+- **Correlate logs by trace/ID** to see the per-stage timing the spans don't
+  capture (e.g., a "waited Ns for a slot" or "queue depth N" log line).
+
+If you cannot produce one of these, you have a hypothesis, not a root cause —
+say so.
+
+### 7. Name the fix and its lever class
+
+State the fix as: *which constant/resource, on which service, changed from what
+to what, and why that's the right lever class* (concurrency constant vs. CPU vs.
+replicas vs. architecture). If it's an architectural ceiling (step 5, row 4),
+say plainly that no sizing knob fixes it and what the real fix is (a code change
+or an upstream issue), rather than recommending tuning that you've proven won't
+help.
+
+**Before declaring an architectural ceiling, check the load is realistic.** A
+synthetic shape concentrated on one tenant, key, or shard — which production
+rate-limits or spreads — can manufacture a ceiling real traffic never hits.
+Confirm the traffic shape is representative before you burn effort on what may
+be an artifact.
+
+## Discipline that keeps you honest
+
+Skipping these is how investigations go in circles for days.
+
+- **Pre-register hypotheses.** Before any change, write the competing
+  hypotheses and their predictions: "If it's the connection pool (H1), raising
+  it drops p95 and the queue clears. If it's a downstream stall (H2), raising it
+  changes nothing." Then the next test is decisive instead of ambiguous.
+- **Change one variable at a time.** Bundling three changes means a green (or
+  red) result tells you nothing about which one mattered. The temptation to fix
+  everything at once destroys attribution.
+- **Beware environmental drift.** If a known-good config stops reproducing the
+  old result, suspect the environment moved, not just the config — a service
+  OOM'd and recovered, a database was resized, a cache grew, a catalog
+  accumulated.
+- **Watch for the bottleneck *moving*.** Each fix often exposes the next gate.
+  That's progress, but name it: "this is a new bottleneck, one hop down," not "the
+  fix didn't work." Re-run the loop from step 4 on the new symptom.
+
+## Tool reference
+
+Concrete query patterns for Prometheus (CPU, throttling, queue depth),
+Tempo (fetch + decompose a trace, find slow traces), and Loki (correlate by
+trace ID, read backlog/wait logs) are in
+[references/grafana-queries.md](references/grafana-queries.md). Read it when you
+need the exact queries; the method above is what matters first.

--- a/.claude/skills/perf-investigation/references/grafana-queries.md
+++ b/.claude/skills/perf-investigation/references/grafana-queries.md
@@ -1,0 +1,204 @@
+# Grafana query reference (Prometheus / Tempo / Loki)
+
+Concrete query patterns for a GoodData.CN-style stack on Kubernetes, via the
+Grafana MCP tools. Replace `NAMESPACE`, service/job names, and time bounds with
+your own. These are starting points — adapt label names to what your cluster
+actually exposes (use the metric/label discovery tools first if unsure).
+
+Contents:
+- Conventions and gotchas
+- Prometheus — CPU, throttling, memory, latency, **backlog/queue depth**, pools
+- Tempo — fetch + decompose a trace, find slow traces
+- Loki — correlate by trace ID, read timing/backlog logs
+- Reading source when a constant is opaque
+
+## Conventions and gotchas
+
+- **Datasource UIDs**: typically `prometheus`, `loki`, `tempo`. Confirm with the
+  datasource-list tool if queries return nothing.
+- **Time formats differ by tool.** Prometheus tools accept relative (`now-25m`)
+  and RFC3339. Loki tools generally want **RFC3339** (`2026-06-10T14:30:00Z`) —
+  `now-25m` will error. Tempo proxy search/lookup wants **unix seconds** for
+  `start`/`end`. Convert with `date -u -d @<unix>` / `date -u +%s`.
+- **Big results overflow.** A full trace or a wide log query can exceed the
+  response limit. Prefer `jq`-filtered Tempo lookups and `count_over_time` /
+  `| json | unwrap` Loki aggregations over dumping raw lines.
+- **Find the load window first.** Most investigations start by locating the
+  burst in the request-rate metric, then zooming every other query to it.
+
+## Prometheus — the resource picture
+
+Find the load window (request rate; idle baseline is low, a test/burst spikes):
+
+```promql
+sum(rate(http_server_requests_seconds_count{job=~".*<service>.*"}[1m]))
+```
+
+Per-pod CPU usage (compare against the pod's CPU *limit* to judge headroom):
+
+```promql
+sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="NAMESPACE", pod=~"<service>.*", container!=""}[2m]))
+```
+
+**CFS throttling ratio** — the critical companion to CPU. A pod can show low
+*average* CPU yet be throttled in bursts; and a pod with idle CPU and ~0
+throttling that is still slow is **not** CPU-bound (look for a concurrency
+constant instead):
+
+```promql
+sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="NAMESPACE", pod=~"<service>.*"}[2m]))
+  / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="NAMESPACE", pod=~"<service>.*"}[2m]))
+```
+
+Memory working set vs. limit (catch OOM risk / pods near their ceiling):
+
+```promql
+max by (pod) (container_memory_working_set_bytes{namespace="NAMESPACE", pod=~"<service>.*", container!=""}) / 1024 / 1024
+kube_pod_container_resource_limits{namespace="NAMESPACE", pod=~"<service>.*", resource="memory"} / 1024 / 1024
+```
+
+Per-endpoint latency (mean over the window; swap `_sum`/`_count` for a
+histogram quantile if buckets exist):
+
+```promql
+sum by (uri) (rate(http_server_requests_seconds_sum{job=~".*<service>.*"}[3m]))
+  / sum by (uri) (rate(http_server_requests_seconds_count{job=~".*<service>.*"}[3m]))
+```
+
+gRPC server-side latency (service-to-service hops):
+
+```promql
+sum by (method) (rate(grpc_server_call_duration_seconds_sum{job=~".*<service>.*"}[3m]))
+  / sum by (method) (rate(grpc_server_call_duration_seconds_count{job=~".*<service>.*"}[3m]))
+```
+
+**Queue / backlog depth** — where work piles up. For async hops via Pulsar.
+
+The **unacked-message backlog** is a frequent, non-obvious cause of slowdown:
+these are messages delivered to a consumer that were never acknowledged (the
+consumer is stuck mid-processing or blocked on its own downstream), so the work
+shows up in *neither* CPU nor request-rate while everything queued behind it
+stalls. Check it early and across **all** topics, not just the one you suspect:
+
+```promql
+sum(pulsar_consumer_unacked_messages{cluster_name=~"$cluster", topic=~"persistent://${ns}/.*"}) by (topic)
+```
+
+Plain backlog (messages not yet delivered) and the per-subscription view:
+
+```promql
+sum by (topic) (pulsar_msg_backlog{topic=~".*<topic>.*"})
+sum by (topic) (pulsar_subscription_unacked_messages{topic=~".*<topic>.*"})
+```
+
+A topic whose unacked count climbs while its consumer service sits at low CPU is
+the async equivalent of the signature-table's "victim" row: the consumer is
+blocked downstream, not slow itself — follow its next hop.
+
+Connection-pool saturation (e.g. JDBC/Hikari) — active pinned at the max with
+pending > 0 means the pool size is the gate:
+
+```promql
+sum by (pod) (hikaricp_connections_active{namespace="NAMESPACE", pod=~"<service>.*"})
+sum by (pod) (hikaricp_connections_pending{namespace="NAMESPACE", pod=~"<service>.*"})
+```
+
+Any service-specific in-flight / active-request gauge is gold for Little's law
+(active requests vs. CPU vs. latency). Discover them with the metric-name search
+tool (look for `*active*`, `*queue*`, `*in_progress*`, `*backpressure*`).
+
+## Tempo — where the wall-clock goes
+
+Fetch a trace by ID via the Grafana → Tempo datasource proxy, and **decompose
+it into a span timeline** (offset from root + duration), which is the single
+most useful artifact in the whole investigation:
+
+```
+GET /api/datasources/proxy/uid/tempo/api/traces/<TRACE_ID>?start=<unixSec>&end=<unixSec>
+```
+
+`jq` to turn the raw trace into an ordered timeline (`+offsetms [durationms]
+service span`):
+
+```jq
+[.batches[]
+ | (.resource.attributes[]? | select(.key=="service.name") | .value.stringValue) as $svc
+ | .scopeSpans[].spans[]
+ | {svc:$svc, name:.name[0:60],
+    start:(.startTimeUnixNano|tonumber/1e9),
+    durMs:(((.endTimeUnixNano|tonumber)-(.startTimeUnixNano|tonumber))/1e6|floor)}]
+| sort_by(.start)
+| (.[0].start) as $t0
+| .[] | "+\(((.start-$t0)*1000)|floor)ms [\(.durMs)ms] \(.svc) \(.name)"
+```
+
+Interpret the timeline as in SKILL.md step 4: find the span that owns the
+wall-clock, then decide whether its time is self-time (a gap with no covering
+children → computing or blocked) or inside children (→ follow the child
+downstream).
+
+Find slow traces in a window (TraceQL, when you have a time range but no ID):
+
+```
+GET /api/datasources/proxy/uid/tempo/api/search?q=<TraceQL>&start=<unixSec>&end=<unixSec>&limit=10
+
+# TraceQL examples (URL-encode):
+{ resource.service.name="<service>" && duration>8s }
+{ resource.service.name="<service>" && name=~".*<endpoint>.*" && duration>5s }
+```
+
+Tempo's recent-window search can lag a minute or two; if a just-finished run
+returns nothing, widen the window slightly or retry.
+
+## Loki — correlate and read the timing logs
+
+Correlate everything for one request by trace ID (services usually log
+`traceId`):
+
+```logql
+{namespace="NAMESPACE"} |= "<TRACE_ID>" | json
+  | line_format "{{.ts}} {{.pod}} {{.action}} {{.msg}}"
+```
+
+Count a recurring event over the window (e.g. timeouts, evictions, retries) —
+use a metric query, not a raw dump:
+
+```logql
+sum(count_over_time({namespace="NAMESPACE", pod=~"<service>.*"} |~ "<error pattern>" [1m]))
+```
+
+Extract a numeric field a service logs (queue wait, in-service duration, bytes)
+and aggregate it — this is how you confirm "compute was Xms but the task waited
+Ns":
+
+```logql
+avg(avg_over_time({namespace="NAMESPACE", pod=~"<service>.*"} |= "<marker>" | json | unwrap <numeric_field> [1m]))
+```
+
+Pull the peer/target a stalled call was waiting on (regex out an IP/host to see
+whether all timeouts point at **one** node — a hot-shard signature):
+
+```logql
+{namespace="NAMESPACE", pod=~"<service>.*"} |~ "<timeout marker>"
+  | regexp "peer ipv4:(?P<peer>[0-9.]+)" | line_format "{{.peer}}"
+```
+
+If a single peer owns ~100% of the timeouts while that node has idle CPU, you're
+looking at a per-node coordination/hot-shard ceiling, not a sizing problem.
+
+## Reading source when a constant is opaque
+
+When you suspect a hardcoded concurrency constant but can't find its value or
+override, the image is often public. Pull it and read the real default and the
+env-var convention rather than guessing:
+
+```bash
+docker pull <registry>/<image>:<tag>
+docker create --name tmp <registry>/<image>:<tag>
+docker export tmp | tar -x -C ./rootfs --wildcards '*<relevant-path>*'
+# then grep the source/config for the default and its env override
+```
+
+This turns "I think the pool is small" into "it's N, overridable via `<ENV_VAR>`"
+— the difference between a guess and a fix. The value being *knowable* is the
+point, not any particular number.

--- a/.claude/skills/perf-investigation/references/request-flow.md
+++ b/.claude/skills/perf-investigation/references/request-flow.md
@@ -1,0 +1,115 @@
+# GoodData.CN request flow (for perf investigation)
+
+The dependency map you need for step 3 (map the request path) and for telling a
+**cause** apart from a **victim**. Annotated with what tends to gate each hop, so
+you know where to look once a trace points you at a service. This map only names
+the *plausible* downstream; trace decomposition (step 4) is what proves where
+the time actually went.
+
+Contents: Entry and routing · AFM execution (the critical path) · Export flow ·
+Verifying the map against the live system.
+
+## Entry and routing
+
+```
+Client (HTTPS) → Ingress (TLS, LB) → api-gw (gateway) → backend service
+```
+
+`api-gw` authenticates, resolves the organization, applies rate limits, and
+**forwards** each request to a backend over an HTTP client. That forward path
+holds a connection for the *entire* downstream execution, so under load the
+gateway's forward connection pool is a common, non-obvious throughput ceiling —
+api-gw itself can sit near-idle while requests queue waiting for a forward slot.
+
+Routing (URL pattern → backend), from the gateway's application config:
+
+| Path pattern | Backend |
+|---|---|
+| `/api/v*/actions/workspaces/*/execution/*`, `/ai/*`, `/ailake/*` | afm-exec-api |
+| `/api/v*/auth/*`, `/login*`, `/oauth2/*`, `/logout`, `/api/v*/profile` | auth-service |
+| `/api/v*/actions/workspaces/*/automations/*`, `/actions/notificationChannels/*` | automation |
+| `/api/v*/actions/dataSources/*/scan*`, `/test` | scan-model |
+| `/api/v*/actions/workspaces/*/export/(tabular\|visual\|raw\|slides\|image)*` | export-controller |
+| `/api/v*/actions/collectCacheUsage`, `/actions/fileStorage/*` | result-cache |
+| `/api/v*/entities/*`, `/api/v*/layout/*`, `/api/v*/actions/*` (catch-all) | metadata-api |
+| `/analyze/*`, `/dashboards/*`, `/modeler/*`, `/*` (UI static assets) | api-gateway |
+
+So: a slow `/execution/...` is afm-exec-api's chain; a slow `/profile` or
+`/login` is auth-service (which itself calls metadata-api); a slow `/entities`
+or `/layout` is metadata-api directly. Knowing this stops you investigating the
+wrong backend for a given slow URL.
+
+## AFM execution — the critical path
+
+This is the workflow behind dashboard/report loads and the one most worth
+understanding. GoodData generates SQL; the customer's own data source executes
+it.
+
+```
+POST .../execution/afm/execute
+  └─ afm-exec-api            parse AFM, resolve MAQL, orchestrate
+       ├─(gRPC) metadata-api    LDM, data-source config, permissions   [sync]
+       ├─(gRPC) calcique        MAQL → SQL (Calcite)                    [sync]
+       └─(gRPC) result-cache    register execution, check cache         [sync]
+            │
+            ▼  CACHE MISS only:
+            result-cache ──(Pulsar: sql.select)──▶ sql-executor          [async]
+                 sql-executor: JDBC to customer data source, then
+                   stores raw result into quiver (Arrow Flight DoPut)
+                 sql-executor ──(Pulsar: execution.finish)──▶ result-cache [async]
+            result-cache ──(Pulsar: result.xtab)──▶ quiver dataframe      [async]
+                 quiver: cross-tabulate / pivot / sort / paginate (polars)
+  → afm-exec-api returns a resultId
+
+GET .../execution/afm/execute/result/{resultId}
+  └─ served from quiver (Arrow Flight DoGet), paginated                  [sync]
+```
+
+Reading this for diagnosis:
+
+- **Cache hit vs. miss is the biggest latency fork.** A hit skips the entire
+  Pulsar/sql-executor/cross-tab path and just serves the stored result flight.
+  If "slow" correlates with misses, the question becomes *why so many misses*
+  (working set vs. cache capacity, eviction churn, cache-key volatility), which
+  can be a far bigger lever than tuning any single service.
+- **`sql.select` backlog** building = the cache-miss SQL path can't keep up.
+  But check *why*: sql-executor may be idle and blocked on its **downstream**
+  (the Arrow Flight DoPut into quiver, or the customer data source itself) —
+  classic victim-not-cause. Compare sql-executor CPU and its fetch-vs-exec time.
+- **`result.xtab` backlog / cross-tab latency** = the dataframe/cross-tab stage.
+  The compute is usually tiny; if tasks sit a long time, they're queued or
+  blocked on reading their input flight from the cache tier (again, follow the
+  trace before blaming the cross-tab service).
+- **Result fetch (`/result/{id}`)** is a synchronous read from the cache tier.
+  If *that* is slow while the cache node has spare CPU, suspect a per-node
+  coordination/consistency gate or a hot shard rather than throughput.
+- **metadata-api and calcique are on the synchronous front of every execute**,
+  so if they're slow (e.g., a connection-pool or DB ceiling on metadata-api),
+  *every* report pays it — a uniform per-request tax across many endpoints is a
+  tell for this rather than for the per-report compute path.
+
+## Export flow (lower-frequency, but heavy)
+
+```
+POST .../export/(tabular|visual|raw|slides)
+  └─ export-controller   (lifecycle/state in Redis)
+       └─(Pulsar: export-*-scheduled.request)──▶
+            tabular-exporter (CSV/XLSX)                    OR
+            export-builder (PDF/PPTX/PNG via headless Chromium)
+  → stored in object storage
+```
+
+Exports are async and resource-heavy (headless browser for visual/PDF). They
+rarely cause interactive-load slowness, but they can compete for cluster CPU and
+memory during a window — worth checking if "slow" coincides with a burst of
+exports.
+
+## How to verify this map against the live system
+
+Don't trust a static map blindly — services and routing evolve. Confirm against
+the running system:
+- The **trace** is the authoritative dependency graph for a given request.
+- The **gateway routing** is in api-gw's application config (URL pattern →
+  backend).
+- **Pulsar topic** names appear in both metrics (`pulsar_msg_backlog{topic=...}`)
+  and consumer logs — use them to watch the async hops above.


### PR DESCRIPTION
## What

Adds a new agent skill, `perf-investigation`, for **diagnosing performance bottlenecks in a deployed GoodData.CN stack from observability data** — given a slow trace ("why is trace `abc123` taking 13s?") or a time-bounded report ("dashboards were slow ~10 min ago"). It is post-hoc diagnosis, **not** load-test running.

## Why

Distilled from a long real performance investigation. The recurring lesson: the symptom is rarely where the cause is, and most gates are small hardcoded concurrency constants throttling a service that sits at low CPU — so the reflex to "add pods/CPU" is usually wrong. The skill encodes a repeatable method so the next investigation doesn't rediscover this the hard way.

## Contents

- **`SKILL.md`** — the method: pin the symptom (ask the user when ambiguous) → reproduce evidence before theorizing → map the request path → localize via trace decomposition → classify with a **signature table** (idle CPU + deep queue = a concurrency constant; cause vs. victim; architectural ceilings; pool limits; burstable-credit cliffs) → prove (Little's law, read the image source) → name the fix and its lever class. Plus discipline (pre-register hypotheses, one variable at a time, environmental drift) and a workload-realism check before declaring an architectural wall.
- **`references/grafana-queries.md`** — Prometheus/Tempo/Loki query cookbook: CPU + CFS throttling, latency, **Pulsar unacked backlog** (a common non-obvious culprit), the `jq` span-timeline decomposition, slow-trace search, log correlation, and the pull-the-image-and-read-the-source recipe.
- **`references/request-flow.md`** — the GoodData.CN request flow (gateway routing, AFM execution chain) annotated for where bottlenecks live, for cause-vs-victim reasoning.

Public/customer-facing: generic service names only, no internal cluster/org/repo references.

## Notes for reviewers

- The routing patterns and Pulsar topic names in `request-flow.md` are the bits most worth a second look before this is treated as public-facing docs.
- Skill content only — no Terraform/infra changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)