### PR TITLE
feat(azure): provision Premium SSD default storage class

### DIFF
--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -66,6 +66,10 @@ module "k8s_common" {
 
   depends_on = [
     azurerm_kubernetes_cluster.main,
+    # Premium SSD must be the default storage class before any Helm release
+    # provisions PVCs, so all persistent volumes land on premium SSDs.
+    kubernetes_storage_class_v1.premium_ssd,
+    kubernetes_annotations.demote_standardssd_default,
     azurerm_role_assignment.gdcn_blob_contrib,
     azurerm_federated_identity_credential.gdcn,
     # Image cache plumbing must outlive the helm releases: pre-delete hooks

--- a/azure/storage-class.tf
+++ b/azure/storage-class.tf
@@ -1,0 +1,53 @@
+###
+# Kubernetes storage classes for AKS
+###
+
+# AKS ships StandardSSD_LRS as the cluster default ("default"/"managed-csi").
+# Provision a Premium SSD (Premium_LRS) class and make it the cluster default
+# so all GoodData.CN persistent volumes (Pulsar, etcd, redis-ha, Qdrant,
+# observability) land on premium SSDs. WaitForFirstConsumer matches the AKS
+# built-ins so zone-aware scheduling still works.
+resource "kubernetes_storage_class_v1" "premium_ssd" {
+  metadata {
+    name = "premium-ssd"
+
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "disk.csi.azure.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    skuname = "Premium_LRS"
+  }
+
+  depends_on = [azurerm_kubernetes_cluster.main]
+}
+
+# Demote the built-in StandardSSD default classes so exactly one default class
+# (premium-ssd) remains. These StorageClasses are owned by AKS; only the
+# is-default-class annotation is patched via server-side apply.
+resource "kubernetes_annotations" "demote_standardssd_default" {
+  for_each = toset(["default", "managed-csi"])
+
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+
+  metadata {
+    name = each.value
+  }
+
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" = "false"
+  }
+
+  # The built-in classes carry this annotation from a different field manager;
+  # take ownership of it rather than erroring on the conflict.
+  force = true
+
+  depends_on = [azurerm_kubernetes_cluster.main]
+}


### PR DESCRIPTION
## Summary

AKS ships `StandardSSD_LRS` as the cluster default storage class, so all GoodData.CN persistent volumes (Pulsar, etcd, redis-ha, Qdrant, observability) were landing on standard SSDs. This change provisions a Premium SSD class and makes it the cluster default so all persistent volumes use premium SSDs.

- Add `azure/storage-class.tf`: a `premium-ssd` StorageClass (`disk.csi.azure.com`, `skuname=Premium_LRS`, `WaitForFirstConsumer`, volume expansion enabled) marked as the cluster default.
- Demote the built-in StandardSSD default classes (`default`, `managed-csi`) so exactly one default class remains.
- Wire the storage-class resources into the `k8s_common` module `depends_on` so the premium default exists before any Helm release provisions PVCs.

Mirrors the existing AWS `modules/k8s-aws/storage-class.tf` pattern. StarRocks is AWS-only and is the only chart that hardcodes a storage class, so no shared-module change was needed; aws/local are untouched.

## Note on existing volumes

A PVC's `storageClassName` is immutable, so this affects **new** volumes only. A fresh deploy lands everything on Premium SSD. Already-bound PVCs on a running cluster stay on StandardSSD until their PVCs are recreated.

## Testing

- `terraform fmt -recursive` — no diff
- `terraform validate` (azure) — Success
- `terraform plan` (targeted) — 3 to add, 0 to change, 0 to destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)