### PR TITLE
chore: scrub internal references from dashboard and starrocks profile

### DIFF
--- a/modules/k8s-common/dashboards/gooddata-cn-overall-health.json
+++ b/modules/k8s-common/dashboards/gooddata-cn-overall-health.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Single-pane-of-glass overview. Open this first during any incident.\n\nGoodData CN Service Reference:\n  tiger-*          All GoodData CN services use this prefix (e.g. tiger-gateway = API Gateway)\n  Calcique         Analytics Engine — computes dashboard & report queries\n  Result Cache     Stores computed results to avoid re-running identical queries\n  SQL Executor     Runs queries against your external data sources\n  Pulsar           Internal message queue for background job processing\n  Export Builder   Renders PDF/PNG exports using headless Chrome\n  Hikari           Database connection pool — number of open DB connections per service",
+  "description": "Single-pane-of-glass overview. Open this first during any incident.\n\nGoodData CN Service Reference:\n  Calcique         Analytics Engine — computes dashboard & report queries\n  Result Cache     Stores computed results to avoid re-running identical queries\n  SQL Executor     Runs queries against your external data sources\n  Pulsar           Internal message queue for background job processing\n  Export Builder   Renders PDF/PNG exports using headless Chrome\n  Hikari           Database connection pool — number of open DB connections per service",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -4336,8 +4336,9 @@
       },
       {
         "current": {
-          "text": "iad1",
-          "value": "iad1"
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -4359,8 +4360,8 @@
       },
       {
         "current": {
-          "text": "tiger-ga",
-          "value": "tiger-ga"
+          "text": "gooddata-cn",
+          "value": "gooddata-cn"
         },
         "datasource": {
           "type": "prometheus",
@@ -4371,7 +4372,7 @@
         "name": "ns",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{cluster_name=~\"$cluster\", namespace=~\".*tiger.*|.*gooddata.*|.*adhoc.*\"}, namespace)",
+          "query": "label_values(kube_pod_info{cluster_name=~\"$cluster\", namespace=~\".*gooddata.*\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/modules/k8s-common/templates/starrocks-size-prod-xl.yaml.tftpl
+++ b/modules/k8s-common/templates/starrocks-size-prod-xl.yaml.tftpl
@@ -1,5 +1,4 @@
 # StarRocks sizing: prod-xl (HA FE, XL production CN)
-# Modeled on pdx1/ringcentral with spill bumped to 500Gi per Bohuslav (Slack 2026-05-11):
 # 3 CN nodes x 32 vCPU x 256 GiB memory, ~0.5 TB spill and data cache.
 
 starrocks:


### PR DESCRIPTION
## What

Removes GoodData-internal identifiers that leaked into the public distribution's shipped files. No functional/sizing changes.

## Changes

**`modules/k8s-common/templates/starrocks-size-prod-xl.yaml.tftpl`**
- Dropped the provenance comment naming an internal cluster (`pdx1`), customer (`ringcentral`), an employee, and a Slack thread. The sizing spec it described (`3 CN nodes x 32 vCPU x 256 GiB…`) is preserved.

**`modules/k8s-common/dashboards/gooddata-cn-overall-health.json`** (shipped Grafana dashboard)
- `Cluster` variable default `iad1` → `All` (`$__all`) — it's a `label_values` query var with includeAll, so this is the natural neutral default.
- `Namespace` variable default `tiger-ga` → `gooddata-cn` (this repo's actual default namespace).
- Namespace dropdown query regex `.*tiger.*|.*gooddata.*|.*adhoc.*` → `.*gooddata.*`, dropping internal `tiger`/`adhoc` namespace names.
- Removed the service-prefix legend line (`tiger-* … e.g. tiger-gateway = API Gateway`) entirely. There is no uniform service prefix in this distribution — panels match raw container names like `api-gw`, `gateway-api-gw`, `calcique`, `metadata-api`, `sql-executor` — so the legend was simply false. The accurate component glossary (Calcique, Result Cache, SQL Executor, Pulsar, Export Builder, Hikari) is kept.

## Verification

- JSON re-parses valid.
- `terraform fmt -recursive` produces no diff.
- Repo-wide sweep for internal references (`ringcentral`, `pdx1`, `iad1`, `tiger-ga`, `tiger`, `adhoc`, `bohuslav`, `slack`, …) returns zero remaining hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)