### PR TITLE
feat(azure): add Azure DNS support via external-dns

### DIFF
--- a/azure/external-dns.tf
+++ b/azure/external-dns.tf
@@ -1,0 +1,153 @@
+###
+# Azure DNS automation via external-dns
+#
+# When dns_provider = "azure-dns", external-dns runs in the cluster, watches
+# Ingress and Service resources, and maintains A/TXT records in the configured
+# Azure DNS zone. Mirrors the AWS Route 53 wiring in modules/k8s-aws/external-dns.tf.
+###
+
+locals {
+  external_dns_enabled      = var.dns_provider == "azure-dns"
+  external_dns_namespace    = "external-dns"
+  external_dns_txt_owner_id = trimspace(var.deployment_name)
+  external_dns_zone_rg      = local.external_dns_enabled ? trimspace(var.azure_dns_zone_resource_group_name) : ""
+  external_dns_zone_name    = local.external_dns_enabled ? trimspace(var.azure_dns_zone_name) : ""
+
+  # All hostnames Terraform expects to surface via DNS.
+  external_dns_managed_hosts = local.external_dns_enabled ? distinct(compact(concat(
+    [trimspace(var.auth_hostname)],
+    [for org in var.gdcn_orgs : trimspace(org.hostname)],
+    var.enable_observability ? [trimspace(var.observability_hostname)] : []
+  ))) : []
+
+  # Hostnames that aren't a subdomain of the configured zone — these would never
+  # match the zone filter and indicate a misconfiguration.
+  external_dns_invalid_hosts = local.external_dns_enabled ? [
+    for host in local.external_dns_managed_hosts : host
+    if !(host == local.external_dns_zone_name || endswith(host, ".${local.external_dns_zone_name}"))
+  ] : []
+}
+
+data "azurerm_dns_zone" "external_dns" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  name                = local.external_dns_zone_name
+  resource_group_name = local.external_dns_zone_rg
+}
+
+resource "terraform_data" "validate_azure_dns_hostnames" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = length(local.external_dns_invalid_hosts) == 0
+      error_message = "auth_hostname, gdcn_orgs[*].hostname, and observability_hostname (when enable_observability=true) must be within Azure DNS zone '${local.external_dns_zone_name}'. Invalid: ${join(", ", local.external_dns_invalid_hosts)}"
+    }
+  }
+}
+
+# UAMI granted DNS Zone Contributor on the target zone, federated to the
+# external-dns Kubernetes service account via workload identity.
+resource "azurerm_user_assigned_identity" "external_dns" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  name                = "${var.deployment_name}-external-dns-uami"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  tags = local.common_tags
+}
+
+resource "azurerm_role_assignment" "external_dns_zone_contributor" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  scope                = data.azurerm_dns_zone.external_dns[0].id
+  role_definition_name = "DNS Zone Contributor"
+  principal_id         = azurerm_user_assigned_identity.external_dns[0].principal_id
+}
+
+resource "azurerm_federated_identity_credential" "external_dns" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  name      = "external-dns-workload"
+  parent_id = azurerm_user_assigned_identity.external_dns[0].id
+  audience  = ["api://AzureADTokenExchange"]
+  issuer    = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject   = "system:serviceaccount:${local.external_dns_namespace}:external-dns"
+}
+
+resource "kubernetes_namespace_v1" "external_dns" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  metadata {
+    name = local.external_dns_namespace
+    labels = {
+      "azure.workload.identity/use" = "true"
+    }
+  }
+}
+
+resource "helm_release" "external_dns" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  name          = "external-dns"
+  repository    = "https://kubernetes-sigs.github.io/external-dns/"
+  chart         = "external-dns"
+  version       = var.helm_external_dns_version
+  namespace     = kubernetes_namespace_v1.external_dns[0].metadata[0].name
+  wait          = true
+  wait_for_jobs = true
+  timeout       = 1800
+
+  values = [yamlencode({
+    image = {
+      repository = "${local.registry_k8sio}/external-dns/external-dns"
+    }
+    provider      = "azure"
+    policy        = "sync"
+    registry      = "txt"
+    txtOwnerId    = local.external_dns_txt_owner_id
+    txtPrefix     = "gdcn-"
+    domainFilters = [local.external_dns_zone_name]
+    sources       = var.ingress_controller == "istio_gateway" ? ["service"] : ["ingress"]
+
+    serviceAccount = {
+      create = true
+      name   = "external-dns"
+      annotations = {
+        "azure.workload.identity/client-id" = azurerm_user_assigned_identity.external_dns[0].client_id
+      }
+      labels = {
+        "azure.workload.identity/use" = "true"
+      }
+    }
+
+    podLabels = {
+      "azure.workload.identity/use" = "true"
+    }
+
+    # The Azure provider for external-dns needs the resource group + subscription
+    # of the DNS zone; surfacing them as env vars avoids mounting a config file.
+    env = [
+      { name = "AZURE_SUBSCRIPTION_ID", value = data.azurerm_client_config.current.subscription_id },
+      { name = "AZURE_TENANT_ID", value = data.azurerm_client_config.current.tenant_id },
+      { name = "AZURE_RESOURCE_GROUP", value = local.external_dns_zone_rg },
+      { name = "AZURE_USE_WORKLOAD_IDENTITY_EXTENSION", value = "true" },
+    ]
+  })]
+
+  depends_on = [
+    azurerm_role_assignment.external_dns_zone_contributor,
+    azurerm_federated_identity_credential.external_dns,
+    terraform_data.validate_azure_dns_hostnames,
+    # external-dns watches Ingress objects created by the gooddata-cn chart, so
+    # it must come after the rest of the cluster is up. k8s_common owns those
+    # Ingresses; depending on it here keeps the apply order sensible.
+    module.k8s_common,
+  ]
+}
+
+output "azure_dns_zone_name_servers" {
+  description = "Name servers for the Azure DNS zone (when dns_provider = \"azure-dns\"). Configure these at your domain registrar to delegate the zone to Azure DNS."
+  value       = local.external_dns_enabled ? data.azurerm_dns_zone.external_dns[0].name_servers : []
+}

--- a/azure/external-dns.tf
+++ b/azure/external-dns.tf
@@ -87,6 +87,28 @@ resource "kubernetes_namespace_v1" "external_dns" {
   }
 }
 
+# external-dns's Azure provider reads its config from a file (default
+# /etc/kubernetes/azure.json), NOT from env vars. Provide it as a Secret;
+# useWorkloadIdentityExtension makes it auth via the federated SA token that the
+# workload-identity webhook injects (no client secret needed).
+resource "kubernetes_secret_v1" "external_dns_azure" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  metadata {
+    name      = "external-dns-azure-config"
+    namespace = kubernetes_namespace_v1.external_dns[0].metadata[0].name
+  }
+
+  data = {
+    "azure.json" = jsonencode({
+      tenantId                     = data.azurerm_client_config.current.tenant_id
+      subscriptionId               = data.azurerm_client_config.current.subscription_id
+      resourceGroup                = local.external_dns_zone_rg
+      useWorkloadIdentityExtension = true
+    })
+  }
+}
+
 resource "helm_release" "external_dns" {
   count = local.external_dns_enabled ? 1 : 0
 
@@ -126,14 +148,16 @@ resource "helm_release" "external_dns" {
       "azure.workload.identity/use" = "true"
     }
 
-    # The Azure provider for external-dns needs the resource group + subscription
-    # of the DNS zone; surfacing them as env vars avoids mounting a config file.
-    env = [
-      { name = "AZURE_SUBSCRIPTION_ID", value = data.azurerm_client_config.current.subscription_id },
-      { name = "AZURE_TENANT_ID", value = data.azurerm_client_config.current.tenant_id },
-      { name = "AZURE_RESOURCE_GROUP", value = local.external_dns_zone_rg },
-      { name = "AZURE_USE_WORKLOAD_IDENTITY_EXTENSION", value = "true" },
-    ]
+    # Mount azure.json (the Secret above) at the provider's default config path.
+    extraVolumes = [{
+      name   = "azure-config-file"
+      secret = { secretName = kubernetes_secret_v1.external_dns_azure[0].metadata[0].name }
+    }]
+    extraVolumeMounts = [{
+      name      = "azure-config-file"
+      mountPath = "/etc/kubernetes"
+      readOnly  = true
+    }]
   })]
 
   depends_on = [

--- a/azure/external-dns.tf
+++ b/azure/external-dns.tf
@@ -66,14 +66,30 @@ resource "azurerm_role_assignment" "external_dns_zone_contributor" {
   principal_id         = azurerm_user_assigned_identity.external_dns[0].principal_id
 }
 
+data "azurerm_resource_group" "external_dns_zone" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  name = local.external_dns_zone_rg
+}
+
+# external-dns discovers zones with a resource-group-scoped list, which the
+# zone-scoped assignment above does not authorize. Without this it 403s on every sync.
+resource "azurerm_role_assignment" "external_dns_zone_rg_reader" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  scope                = data.azurerm_resource_group.external_dns_zone[0].id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.external_dns[0].principal_id
+}
+
 resource "azurerm_federated_identity_credential" "external_dns" {
   count = local.external_dns_enabled ? 1 : 0
 
-  name      = "external-dns-workload"
-  parent_id = azurerm_user_assigned_identity.external_dns[0].id
-  audience  = ["api://AzureADTokenExchange"]
-  issuer    = azurerm_kubernetes_cluster.main.oidc_issuer_url
-  subject   = "system:serviceaccount:${local.external_dns_namespace}:external-dns"
+  name                      = "external-dns-workload"
+  user_assigned_identity_id = azurerm_user_assigned_identity.external_dns[0].id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject                   = "system:serviceaccount:${local.external_dns_namespace}:external-dns"
 }
 
 resource "kubernetes_namespace_v1" "external_dns" {
@@ -81,10 +97,11 @@ resource "kubernetes_namespace_v1" "external_dns" {
 
   metadata {
     name = local.external_dns_namespace
-    labels = {
-      "azure.workload.identity/use" = "true"
-    }
   }
+
+  # Azure RBAC is on and the provider uses the non-admin kubeconfig, so this
+  # grant is what authorizes every Kubernetes API call below.
+  depends_on = [azurerm_role_assignment.aks_creator_cluster_admin]
 }
 
 # external-dns's Azure provider reads its config from a file (default
@@ -107,6 +124,8 @@ resource "kubernetes_secret_v1" "external_dns_azure" {
       useWorkloadIdentityExtension = true
     })
   }
+
+  depends_on = [azurerm_role_assignment.aks_creator_cluster_admin]
 }
 
 resource "helm_release" "external_dns" {
@@ -160,14 +179,17 @@ resource "helm_release" "external_dns" {
     }]
   })]
 
+  # Deliberately does NOT depend on module.k8s_common: external-dns watches for
+  # Ingresses/Services, so it can start first, and k8s_common depends on it so
+  # DNS resolves before cert-manager opens its first ACME HTTP-01 challenge.
   depends_on = [
     azurerm_role_assignment.external_dns_zone_contributor,
+    azurerm_role_assignment.external_dns_zone_rg_reader,
     azurerm_federated_identity_credential.external_dns,
     terraform_data.validate_azure_dns_hostnames,
-    # external-dns watches Ingress objects created by the gooddata-cn chart, so
-    # it must come after the rest of the cluster is up. k8s_common owns those
-    # Ingresses; depending on it here keeps the apply order sensible.
-    module.k8s_common,
+    # Image comes from the k8sio cache rule when enable_image_cache is set.
+    azurerm_container_registry_cache_rule.k8sio,
+    azurerm_role_assignment.aks_acr_pull,
   ]
 }
 

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -159,18 +159,9 @@ locals {
 }
 
 output "manual_dns_records" {
-  description = "DNS records to create for Azure ingress."
-  value = var.ingress_controller == "ingress-nginx" && local.ingress_lb_ip != "" ? [
-    for hostname in distinct(compact(concat(
-      [module.k8s_common.auth_hostname],
-      module.k8s_common.org_domains,
-      var.enable_observability ? [trimspace(var.observability_hostname)] : []
-      ))) : {
-      hostname    = hostname
-      record_type = "A"
-      value       = local.ingress_lb_ip
-    }
-    ] : (var.ingress_controller == "istio_gateway" && local.istio_ingress_lb_ip != "" ? [
+  description = "DNS records to create for Azure ingress. Empty when dns_provider = \"azure-dns\" — external-dns maintains the records automatically."
+  value = local.external_dns_enabled ? [] : (
+    var.ingress_controller == "ingress-nginx" && local.ingress_lb_ip != "" ? [
       for hostname in distinct(compact(concat(
         [module.k8s_common.auth_hostname],
         module.k8s_common.org_domains,
@@ -178,7 +169,18 @@ output "manual_dns_records" {
         ))) : {
         hostname    = hostname
         record_type = "A"
-        value       = local.istio_ingress_lb_ip
+        value       = local.ingress_lb_ip
       }
-  ] : [])
+      ] : (var.ingress_controller == "istio_gateway" && local.istio_ingress_lb_ip != "" ? [
+        for hostname in distinct(compact(concat(
+          [module.k8s_common.auth_hostname],
+          module.k8s_common.org_domains,
+          var.enable_observability ? [trimspace(var.observability_hostname)] : []
+          ))) : {
+          hostname    = hostname
+          record_type = "A"
+          value       = local.istio_ingress_lb_ip
+        }
+    ] : [])
+  )
 }

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -81,6 +81,9 @@ module "k8s_common" {
     azurerm_container_registry_credential_set.dockerio,
     azurerm_role_assignment.aks_acr_pull,
     azurerm_role_assignment.acr_credential_set_secrets_user,
+    # DNS must resolve before cert-manager issues its first Let's Encrypt cert;
+    # a failed issuance backs off up to 32h. No-op unless dns_provider=azure-dns.
+    helm_release.external_dns,
   ]
 }
 

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -46,9 +46,24 @@ size_profile = "prod-small"
 ###
 # DNS
 ###
-# Azure DNS records must be managed externally.
-# Terraform outputs the public IP address and required DNS records.
+
+# Option 1 — Self-managed DNS
+# Terraform outputs the LoadBalancer's public IP and the records you need to create
+# (auth/org/observability hostnames → IP). You create them in your DNS provider.
 dns_provider = "self-managed"
+
+# Option 2 — Azure DNS (managed via external-dns)
+# Terraform expects an existing Azure DNS public zone and deploys external-dns
+# inside the cluster. external-dns watches Ingress (or, for istio_gateway, the
+# Istio LoadBalancer Service) and continuously syncs A/TXT records into the zone.
+# Cost: ~$0.50/zone/month + ~$0.40 per million queries.
+#
+# Delegate your domain to Azure DNS by pointing your registrar at the name
+# servers from the `azure_dns_zone_name_servers` output before you rely on it.
+#
+# dns_provider                       = "azure-dns"
+# azure_dns_zone_name                = "gooddata.example.com"
+# azure_dns_zone_resource_group_name = "my-dns-rg"
 
 ###
 # Ingress + TLS

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -43,6 +43,26 @@ variable "azure_additional_tags" {
   default     = {}
 }
 
+variable "azure_dns_zone_name" {
+  description = "Name of the existing Azure DNS public zone used by external-dns when dns_provider = \"azure-dns\" (e.g. \"example.com\"). The zone must already exist in your subscription."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.dns_provider != "azure-dns" || length(trimspace(var.azure_dns_zone_name)) > 0
+    error_message = "azure_dns_zone_name is required when dns_provider is \"azure-dns\"."
+  }
+}
+
+variable "azure_dns_zone_resource_group_name" {
+  description = "Name of the resource group that contains the Azure DNS zone referenced by azure_dns_zone_name. Required when dns_provider = \"azure-dns\"."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.dns_provider != "azure-dns" || length(trimspace(var.azure_dns_zone_resource_group_name)) > 0
+    error_message = "azure_dns_zone_resource_group_name is required when dns_provider is \"azure-dns\"."
+  }
+}
+
 variable "azure_location" {
   description = "Azure location to deploy resources to."
   type        = string
@@ -73,12 +93,12 @@ variable "deployment_name" {
 }
 
 variable "dns_provider" {
-  description = "DNS management mode on Azure. Currently only self-managed DNS is supported."
+  description = "DNS management mode on Azure. \"self-managed\" leaves DNS to the user; \"azure-dns\" deploys external-dns wired to an existing Azure DNS zone and automatically maintains A records for each GoodData hostname."
   type        = string
   default     = "self-managed"
   validation {
-    condition     = var.dns_provider == "self-managed"
-    error_message = "dns_provider must be \"self-managed\" on Azure."
+    condition     = contains(["self-managed", "azure-dns"], var.dns_provider)
+    error_message = "dns_provider must be \"self-managed\" or \"azure-dns\"."
   }
 }
 
@@ -184,6 +204,13 @@ variable "helm_cert_manager_version" {
   type        = string
   # renovate: depName=cert-manager registryUrl=https://charts.jetstack.io
   default = "v1.20.3"
+}
+
+variable "helm_external_dns_version" {
+  description = "Version of the external-dns Helm chart to deploy. https://artifacthub.io/packages/helm/external-dns/external-dns"
+  type        = string
+  # renovate: depName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns/
+  default = "1.21.1"
 }
 
 variable "helm_gdcn_version" {


### PR DESCRIPTION
Adds an opt-in `dns_provider = "azure-dns"` mode for Azure so DNS records are maintained automatically instead of by hand, matching the existing AWS Route 53 integration. Terraform deploys external-dns with a user-assigned identity federated via workload identity (no secrets) and DNS Zone Contributor on the zone; external-dns then watches Ingress — or the Istio LoadBalancer Service — and syncs A/TXT records for the auth, org, and observability hostnames. Default `self-managed` behaviour is unchanged.

- Requires an existing Azure DNS public zone; delegate your domain to the name servers in the new `azure_dns_zone_name_servers` output.
- `manual_dns_records` is empty when `azure-dns` is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure DNS management through external-dns, including automatic DNS record synchronization.
  * Added configuration options for Azure DNS zones, resource groups, and the external-dns chart version.
  * Added validation to ensure managed hostnames belong to the configured DNS zone.
  * Added Azure DNS name server output for delegation.

* **Documentation**
  * Updated Azure settings examples to document self-managed and Azure-managed DNS options.

* **Bug Fixes**
  * Prevented duplicate manual DNS records when external-dns is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->