### PR TITLE
feat(sizing): centralize size_profile into per-env size-profiles.tf

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -29,25 +29,7 @@ locals {
     ECRPullThroughCacheMin = aws_iam_policy.ecr_pull_through_cache_min[0].arn
   } : {}
 
-  eks_node_type_presets = {
-    dev        = ["m6a.xlarge", "m6a.2xlarge"]
-    prod-small = ["m8a.xlarge", "m8a.2xlarge"]
-    prod-large = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
-    prod-xl    = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
-  }
-
-  eks_starrocks_node_type_presets = {
-    dev        = ["r8a.large", "m8a.xlarge"]
-    prod-small = ["r8a.large", "r8a.xlarge"]
-    prod-xl    = ["r8a.large", "r8a.8xlarge"]
-  }
-
-  # There is no dedicated prod-large StarRocks profile; fall back to prod-xl
-  # StarRocks sizing when size_profile is prod-large (see gdcn-size-prod-large).
-  starrocks_size_profile_effective = coalesce(var.starrocks_size_profile, var.size_profile == "prod-large" ? "prod-xl" : var.size_profile)
-
-  eks_node_types           = coalesce(var.eks_node_types, local.eks_node_type_presets[var.size_profile])
-  eks_starrocks_node_types = coalesce(var.eks_starrocks_node_types, local.eks_starrocks_node_type_presets[local.starrocks_size_profile_effective])
+  # Node types / StarRocks node types / autoscaler ceiling: resolved in size-profiles.tf.
 
   # Per-AZ node groups for StarRocks so the cluster autoscaler can scale
   # nodes in the AZ where the FE/CN EBS volume lives (EBS is zonal).
@@ -130,7 +112,7 @@ module "eks" {
         }, local.ecr_pull_through_cache_policy)
 
         min_size = 0
-        max_size = var.eks_max_nodes
+        max_size = local.eks_max_nodes
 
         # This value is ignored after the initial creation
         # https://github.com/bryantbiggs/eks-desired-size-hack
@@ -174,7 +156,7 @@ module "eks" {
         }, local.ecr_pull_through_cache_policy)
 
         min_size     = 0
-        max_size     = var.eks_max_nodes
+        max_size     = local.eks_max_nodes
         desired_size = 0
       }
     },

--- a/aws/k8s-aws.tf
+++ b/aws/k8s-aws.tf
@@ -16,7 +16,7 @@ module "k8s_aws" {
   ingress_controller = var.ingress_controller
   dns_provider       = var.dns_provider
   route53_zone_id    = var.route53_zone_id
-  size_profile       = var.size_profile
+  ingress_replicas   = local.profile.ingress_replicas
 
   registry_k8sio = local.registry_k8sio
 

--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -49,8 +49,11 @@ module "k8s_common" {
   gdcn_license_key       = var.gdcn_license_key
   gdcn_orgs              = var.gdcn_orgs
   gdcn_helm_extra_values = var.gdcn_helm_extra_values
-  size_profile           = var.size_profile
-  starrocks_size_profile = local.starrocks_size_profile_effective
+  ingress_replicas       = local.profile.ingress_replicas
+  gdcn_size              = local.profile.gdcn_size
+  pulsar_size            = local.profile.pulsar_size
+  observability_size     = local.profile.observability_size
+  starrocks_size_profile = var.starrocks_size_profile
   cloud                  = "aws"
   ingress_controller     = var.ingress_controller
   gdcn_irsa_role_arn     = aws_iam_role.gdcn_irsa.arn

--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -49,10 +49,27 @@ module "rds_postgresql" {
   engine                      = "postgres"
   engine_version              = data.aws_rds_engine_version.default.version
   family                      = "postgres${split(".", data.aws_rds_engine_version.default.version)[0]}"
-  instance_class              = var.rds_instance_class
-  allocated_storage           = 20
+  instance_class              = local.rds_instance_class
+  allocated_storage           = local.rds_allocated_storage
   apply_immediately           = true
   allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+
+  # Performance parameters tuned by size_profile (see size-profiles.tf). Both are
+  # dynamic (apply_method = immediate, no reboot). shared_buffers/effective_cache_size
+  # are intentionally left to the RDS instance-class defaults, which already scale
+  # with instance memory. Values are in kB.
+  parameters = [
+    {
+      name         = "work_mem"
+      value        = tostring(local.profile.postgres.work_mem_mb * 1024)
+      apply_method = "immediate"
+    },
+    {
+      name         = "maintenance_work_mem"
+      value        = tostring(local.profile.postgres.maintenance_work_mem_mb * 1024)
+      apply_method = "immediate"
+    },
+  ]
 
   # Database name & credentials
   username                    = local.db_username

--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -51,7 +51,7 @@ module "rds_postgresql" {
   family                      = "postgres${split(".", data.aws_rds_engine_version.default.version)[0]}"
   instance_class              = local.rds_instance_class
   allocated_storage           = local.rds_allocated_storage
-  apply_immediately           = true
+  apply_immediately           = var.rds_apply_immediately
   allow_major_version_upgrade = var.rds_allow_major_version_upgrade
 
   # Performance parameters tuned by size_profile (see size-profiles.tf). Both are

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -7,12 +7,12 @@ aws_profile_name = "my-profile"
 # Region to deploy resources to
 aws_region = "eu-central-1"
 
-# Use an existing VPC instead of creating a new one
+# Uncomment to use an existing VPC instead of creating a new one
 # existing_vpc_id             = "vpc-0123456789abcdef0"
 # existing_private_subnet_ids = ["subnet-aaa", "subnet-bbb"]
 # existing_public_subnet_ids  = ["subnet-ccc", "subnet-ddd"]
 
-# Additional tags to apply to all AWS resources
+# Uncomment to apply additional tags to all AWS resources
 # aws_additional_tags = {
 #   Environment = "dev"
 # }
@@ -26,26 +26,29 @@ deployment_name   = "gooddata-cn"
 # GoodData.CN license key
 gdcn_license_key = "key/asdf==" # provided by GoodData
 
-# Additional gooddata-cn Helm values
+# Uncomment to append extra gooddata-cn Helm values
 # gdcn_helm_extra_values = <<-EOT
 #   service:
 #     someComponent:
 #       replicaCount: 3
 # EOT
 
-# Deploys and enables GoodData generative AI services
+# Uncomment to deploy and enable GoodData generative AI services
 # enable_ai_features = true
 
-# Enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
+# Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
 
-# Size profile controls replicas/resources across services:
+# Size profile:
 # - dev: lowest footprint, not HA
-# - prod-small: HA (>= 2 replica per service), resources for services increased
-# - prod-large: HA, sized for large/high-traffic deployments (more replicas +
-#   CPU/memory for the hot-path services than prod-small)
-# NOTE: switching size profile after deploying isn't supported since persistent
-# volume sizes can't be automatically adjusted in-place.
+# - prod-small: HA (>= 2 replicas per service), increased resources
+# - prod-large: HA, sized for large/high-traffic deployments
+# It sets sensible defaults for the metadata DB tier/storage, worker node
+# sizes/counts, observability disk sizes, and GoodData.CN/subchart sizing, so you
+# don't set those individually. To override one default, add its variable here
+# yourself (e.g. rds_instance_class, eks_node_types); see variables.tf for the list.
+# NOTE: changing size_profile after deploying isn't supported (persistent volume
+# sizes can't be resized in place).
 size_profile = "prod-small"
 
 ###
@@ -77,7 +80,7 @@ tls_mode           = "acm"
 # tls_mode           = "letsencrypt"
 # letsencrypt_email  = "me@example.com"
 
-# When ingress-nginx sits behind another L7 proxy/load balancer, set this to true.
+# Uncomment when ingress-nginx sits behind another L7 proxy/load balancer.
 # ingress_nginx_behind_l7 = true
 
 # Option 3 — Istio Gateway + Let's Encrypt certificates (letsencrypt)
@@ -121,8 +124,8 @@ gdcn_orgs = [
 # Uncomment to enable the observability stack
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
-#
-# Observability data retention (optional; defaults shown). Each signal has its own 5Gi
+
+# Uncomment to override data retention (defaults shown). Each signal has its own 5Gi
 # PVC, so lower these to bound storage. Loki must be a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
@@ -143,15 +146,14 @@ gdcn_orgs = [
 # enable_ai_lake = true
 
 ###
-# EKS & infrastructure sizing (optional)
+# EKS & infrastructure (optional)
 ###
+# Uncomment to override EKS defaults
 # eks_version                      = "1.35"
-# eks_node_types                   = ["m6i.xlarge"]
-# eks_max_nodes                    = 10
 # eks_endpoint_public_access       = true
 # eks_endpoint_public_access_cidrs = ["x.x.x.x/32"]
 # eks_endpoint_private_access      = false
 
-# rds_instance_class      = "db.t4g.medium"
+# Uncomment to override RDS defaults
 # rds_deletion_protection = false
 # rds_skip_final_snapshot = true

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -125,8 +125,9 @@ gdcn_orgs = [
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
 
-# Uncomment to override data retention (defaults shown). Each signal has its own 5Gi
-# PVC, so lower these to bound storage. Loki must be a multiple of 24h.
+# Uncomment to override data retention (defaults shown). Each signal has its own
+# PVC sized by size_profile (5Gi dev / 10Gi prod-small / 20Gi prod-large), so
+# lower these to bound storage. Loki must be a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
 # tempo_retention_period      = "168h"

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -143,8 +143,10 @@ gdcn_orgs = [
 ###
 # GoodData AI Lake (optional)
 ###
-# Uncomment to deploy AI Lake (additional license required)
-# enable_ai_lake = true
+# Uncomment to deploy AI Lake (additional license required). Both lines are
+# required; starrocks_size_profile is one of: dev, prod-small, prod-xl.
+# enable_ai_lake         = true
+# starrocks_size_profile = "prod-small"
 
 ###
 # EKS & infrastructure (optional)

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -47,8 +47,8 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 # sizes/counts, observability disk sizes, and GoodData.CN/subchart sizing, so you
 # don't set those individually. To override one default, add its variable here
 # yourself (e.g. rds_instance_class, eks_node_types); see variables.tf for the list.
-# NOTE: changing size_profile after deploying isn't supported (persistent volume
-# sizes can't be resized in place).
+# NOTE: changing size_profile after deploying isn't a supported migration; PVCs
+# can't shrink, and growing them is a manual, storage-class-dependent step.
 size_profile = "prod-small"
 
 ###
@@ -157,6 +157,8 @@ gdcn_orgs = [
 # eks_endpoint_public_access_cidrs = ["x.x.x.x/32"]
 # eks_endpoint_private_access      = false
 
-# Uncomment to override RDS defaults
+# Uncomment to override RDS defaults. apply_immediately reboots the DB to apply
+# changes (e.g. an instance-class change) instead of waiting for maintenance.
+# rds_apply_immediately   = false
 # rds_deletion_protection = false
 # rds_skip_final_snapshot = true

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -1,0 +1,97 @@
+###
+# Single source of truth for AWS sizing per size_profile: managed infra (RDS,
+# EKS nodes, autoscaler ceiling, ingress replicas) inline, plus workload
+# (GoodData.CN/Pulsar/observability) sizing referenced by name. StarRocks (AI
+# Lake) is sized separately via var.starrocks_size_profile. Override any managed
+# value via the matching var.* input.
+###
+
+locals {
+  size_profiles = {
+    dev = {
+      rds = {
+        instance_class    = "db.t4g.medium"
+        allocated_storage = 20
+      }
+      eks_node_types       = ["m6a.xlarge", "m6a.2xlarge"]
+      starrocks_node_types = ["r8a.large", "m8a.xlarge"]
+      eks_max_nodes        = 6
+      ingress_replicas     = 1
+      postgres = {
+        work_mem_mb             = 8
+        maintenance_work_mem_mb = 128
+      }
+      gdcn_size          = "dev"
+      pulsar_size        = "dev"
+      observability_size = "dev"
+    }
+    prod-small = {
+      rds = {
+        instance_class    = "db.r6g.large"
+        allocated_storage = 100
+      }
+      eks_node_types       = ["m8a.xlarge", "m8a.2xlarge"]
+      starrocks_node_types = ["r8a.large", "r8a.xlarge"]
+      eks_max_nodes        = 12
+      ingress_replicas     = 2
+      postgres = {
+        work_mem_mb             = 16
+        maintenance_work_mem_mb = 256
+      }
+      gdcn_size          = "prod-small"
+      pulsar_size        = "prod-small"
+      observability_size = "prod-small"
+    }
+    prod-large = {
+      rds = {
+        instance_class    = "db.r6g.xlarge"
+        allocated_storage = 100
+      }
+      eks_node_types = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
+      # Unused: StarRocks has no prod-large tier (starrocks_size_profile can only
+      # be dev/prod-small/prod-xl), so this is never selected. Present for type
+      # consistency across the map.
+      starrocks_node_types = ["r8a.large", "r8a.8xlarge"]
+      eks_max_nodes        = 20
+      ingress_replicas     = 3
+      postgres = {
+        work_mem_mb             = 32
+        maintenance_work_mem_mb = 512
+      }
+      gdcn_size          = "prod-large"
+      pulsar_size        = "prod-large"
+      observability_size = "prod-large"
+    }
+    prod-xl = {
+      rds = {
+        instance_class    = "db.r6g.2xlarge"
+        allocated_storage = 200
+      }
+      eks_node_types       = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
+      starrocks_node_types = ["r8a.large", "r8a.8xlarge"]
+      eks_max_nodes        = 30
+      ingress_replicas     = 3
+      postgres = {
+        work_mem_mb             = 64
+        maintenance_work_mem_mb = 1024
+      }
+      # No prod-xl GDCN/Pulsar/observability spec; fold to prod-large (explicit).
+      gdcn_size          = "prod-large"
+      pulsar_size        = "prod-large"
+      observability_size = "prod-large"
+    }
+  }
+
+  profile = local.size_profiles[var.size_profile]
+
+  # Resolved size_profile values (profile default, overridable via var.*).
+  rds_instance_class    = coalesce(var.rds_instance_class, local.profile.rds.instance_class)
+  rds_allocated_storage = coalesce(var.rds_allocated_storage, local.profile.rds.allocated_storage)
+  eks_node_types        = coalesce(var.eks_node_types, local.profile.eks_node_types)
+  eks_max_nodes         = coalesce(var.eks_max_nodes, local.profile.eks_max_nodes)
+
+  # StarRocks node pool: indexed by the explicit var.starrocks_size_profile, NOT
+  # size_profile (the two are decoupled). Only used when enable_ai_lake is true,
+  # which the variable's validation requires.
+  eks_starrocks_node_types = var.enable_ai_lake ? coalesce(var.eks_starrocks_node_types, local.size_profiles[var.starrocks_size_profile].starrocks_node_types) : []
+}

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -13,10 +13,9 @@ locals {
         instance_class    = "db.t4g.medium"
         allocated_storage = 20
       }
-      eks_node_types       = ["m6a.xlarge", "m6a.2xlarge"]
-      starrocks_node_types = ["r8a.large", "m8a.xlarge"]
-      eks_max_nodes        = 6
-      ingress_replicas     = 1
+      eks_node_types   = ["m6a.xlarge", "m6a.2xlarge"]
+      eks_max_nodes    = 6
+      ingress_replicas = 1
       postgres = {
         work_mem_mb             = 8
         maintenance_work_mem_mb = 128
@@ -30,10 +29,9 @@ locals {
         instance_class    = "db.r6g.large"
         allocated_storage = 100
       }
-      eks_node_types       = ["m8a.xlarge", "m8a.2xlarge"]
-      starrocks_node_types = ["r8a.large", "r8a.xlarge"]
-      eks_max_nodes        = 12
-      ingress_replicas     = 2
+      eks_node_types   = ["m8a.xlarge", "m8a.2xlarge"]
+      eks_max_nodes    = 12
+      ingress_replicas = 2
       postgres = {
         work_mem_mb             = 16
         maintenance_work_mem_mb = 256
@@ -47,13 +45,9 @@ locals {
         instance_class    = "db.r6g.xlarge"
         allocated_storage = 100
       }
-      eks_node_types = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
-      # Unused: StarRocks has no prod-large tier (starrocks_size_profile can only
-      # be dev/prod-small/prod-xl), so this is never selected. Present for type
-      # consistency across the map.
-      starrocks_node_types = ["r8a.large", "r8a.8xlarge"]
-      eks_max_nodes        = 20
-      ingress_replicas     = 3
+      eks_node_types   = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
+      eks_max_nodes    = 20
+      ingress_replicas = 3
       postgres = {
         work_mem_mb             = 32
         maintenance_work_mem_mb = 512
@@ -67,10 +61,9 @@ locals {
         instance_class    = "db.r6g.2xlarge"
         allocated_storage = 200
       }
-      eks_node_types       = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
-      starrocks_node_types = ["r8a.large", "r8a.8xlarge"]
-      eks_max_nodes        = 30
-      ingress_replicas     = 3
+      eks_node_types   = ["m8a.xlarge", "m8a.2xlarge", "m8a.4xlarge"]
+      eks_max_nodes    = 30
+      ingress_replicas = 3
       postgres = {
         work_mem_mb             = 64
         maintenance_work_mem_mb = 1024
@@ -80,6 +73,16 @@ locals {
       pulsar_size        = "prod-large"
       observability_size = "prod-large"
     }
+  }
+
+  # StarRocks node pools are a separate dimension from size_profile: they are
+  # selected by var.starrocks_size_profile (dev/prod-small/prod-xl), which is
+  # decoupled from size_profile, so they live in their own map keyed only by the
+  # valid StarRocks tiers. There is intentionally no prod-large entry.
+  starrocks_node_type_presets = {
+    dev        = ["r8a.large", "m8a.xlarge"]
+    prod-small = ["r8a.large", "r8a.xlarge"]
+    prod-xl    = ["r8a.large", "r8a.8xlarge"]
   }
 
   profile = local.size_profiles[var.size_profile]
@@ -93,5 +96,5 @@ locals {
   # StarRocks node pool: indexed by the explicit var.starrocks_size_profile, NOT
   # size_profile (the two are decoupled). Only used when enable_ai_lake is true,
   # which the variable's validation requires.
-  eks_starrocks_node_types = var.enable_ai_lake ? coalesce(var.eks_starrocks_node_types, local.size_profiles[var.starrocks_size_profile].starrocks_node_types) : []
+  eks_starrocks_node_types = var.enable_ai_lake ? coalesce(var.eks_starrocks_node_types, local.starrocks_node_type_presets[var.starrocks_size_profile]) : []
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -89,9 +89,9 @@ variable "eks_endpoint_public_access_cidrs" {
 }
 
 variable "eks_max_nodes" {
-  description = "Maximum number of EKS worker nodes"
+  description = "Maximum number of EKS worker nodes (autoscaler ceiling). If null, chosen by size_profile."
   type        = number
-  default     = 20
+  default     = null
 }
 
 variable "eks_node_types" {
@@ -101,7 +101,7 @@ variable "eks_node_types" {
 }
 
 variable "eks_starrocks_node_types" {
-  description = "EC2 instance types for the StarRocks-dedicated EKS pool (taint workload=starrocks). If null, defaults to a preset chosen by starrocks_size_profile (or size_profile when unset)."
+  description = "EC2 instance types for the StarRocks-dedicated EKS pool (taint workload=starrocks). If null, defaults to a preset chosen by starrocks_size_profile."
   type        = list(string)
   default     = null
 }
@@ -410,10 +410,10 @@ variable "observability_hostname" {
   }
 }
 
-variable "rds_deletion_protection" {
-  description = "Enable deletion protection on the RDS instance."
-  type        = bool
-  default     = false
+variable "rds_allocated_storage" {
+  description = "RDS PostgreSQL allocated storage in GB. If null, chosen by size_profile."
+  type        = number
+  default     = null
 }
 
 variable "rds_allow_major_version_upgrade" {
@@ -422,10 +422,16 @@ variable "rds_allow_major_version_upgrade" {
   default     = false
 }
 
+variable "rds_deletion_protection" {
+  description = "Enable deletion protection on the RDS instance."
+  type        = bool
+  default     = false
+}
+
 variable "rds_instance_class" {
-  description = "RDS PostgreSQL instance class"
+  description = "RDS PostgreSQL instance class. If null, chosen by size_profile."
   type        = string
-  default     = "db.t4g.medium"
+  default     = null
 }
 
 variable "rds_skip_final_snapshot" {
@@ -455,12 +461,16 @@ variable "size_profile" {
 }
 
 variable "starrocks_size_profile" {
-  description = "Sizing profile for StarRocks (FE/CN pods and dedicated EKS node pool). If null, falls back to size_profile."
+  description = "StarRocks (AI Lake) sizing profile. Required when enable_ai_lake is true; one of: dev, prod-small, prod-xl. Not derived from size_profile."
   type        = string
   default     = null
   validation {
-    condition     = var.starrocks_size_profile == null || contains(["dev", "prod-small", "prod-xl"], coalesce(var.starrocks_size_profile, "dev"))
+    condition     = var.starrocks_size_profile == null || contains(["dev", "prod-small", "prod-xl"], var.starrocks_size_profile)
     error_message = "starrocks_size_profile must be one of: dev, prod-small, prod-xl."
+  }
+  validation {
+    condition     = !var.enable_ai_lake || var.starrocks_size_profile != null
+    error_message = "starrocks_size_profile must be set when enable_ai_lake is true."
   }
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -89,7 +89,7 @@ variable "eks_endpoint_public_access_cidrs" {
 }
 
 variable "eks_max_nodes" {
-  description = "Maximum number of EKS worker nodes (autoscaler ceiling). If null, chosen by size_profile."
+  description = "Maximum worker nodes PER node group (autoscaler ceiling applied to each per-instance-type managed node group and each StarRocks node group independently, so the cluster-wide max is this value times the number of groups). If null, chosen by size_profile."
   type        = number
   default     = null
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -422,6 +422,12 @@ variable "rds_allow_major_version_upgrade" {
   default     = false
 }
 
+variable "rds_apply_immediately" {
+  description = "Apply RDS modifications during terraform apply instead of the next maintenance window. Instance-class changes reboot the database, so leave this off unless you accept downtime."
+  type        = bool
+  default     = false
+}
+
 variable "rds_deletion_protection" {
   description = "Enable deletion protection on the RDS instance."
   type        = bool

--- a/azure/aks.tf
+++ b/azure/aks.tf
@@ -2,6 +2,9 @@
 # Provision AKS cluster
 ###
 
+# AKS worker sizing resolved in size-profiles.tf. The first VM size is the
+# always-on default/system pool; the rest are scale-from-0 user pools.
+
 # Create the AKS cluster
 resource "azurerm_kubernetes_cluster" "main" {
   name                = var.deployment_name
@@ -26,14 +29,15 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
-  # Default node pool
+  # Default (system) node pool. Sized by the first entry of aks_node_vm_sizes;
+  # any further entries become separate user node pools below.
   default_node_pool {
     name                 = "default"
-    vm_size              = var.aks_node_vm_size
+    vm_size              = local.aks_node_vm_sizes[0]
     vnet_subnet_id       = azurerm_subnet.aks.id
     auto_scaling_enabled = true
-    min_count            = var.aks_min_nodes
-    max_count            = var.aks_max_nodes
+    min_count            = local.aks_min_nodes
+    max_count            = local.aks_max_nodes
     node_count           = null
     max_pods             = 110
     os_disk_size_gb      = 100
@@ -68,6 +72,37 @@ resource "azurerm_kubernetes_cluster" "main" {
   http_application_routing_enabled = false
 
 
+
+  tags = local.common_tags
+}
+
+# Additional worker node pools, one per extra entry in aks_node_vm_sizes
+# (the first entry sizes default_node_pool above). Each scales from 0 so the
+# least-waste autoscaler only provisions a larger size when a pending pod
+# needs it. Names are kept short (AKS node pool names are <=12 lowercase
+# alphanumeric chars and cannot encode the full VM size), so they are keyed
+# by position: pool1, pool2, ...
+resource "azurerm_kubernetes_cluster_node_pool" "additional" {
+  for_each = {
+    for idx, size in slice(local.aks_node_vm_sizes, 1, length(local.aks_node_vm_sizes)) :
+    "pool${idx + 1}" => size
+  }
+
+  name                  = each.key
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
+  vm_size               = each.value
+  vnet_subnet_id        = azurerm_subnet.aks.id
+  mode                  = "User"
+
+  auto_scaling_enabled = true
+  min_count            = 0
+  max_count            = local.aks_max_nodes
+  max_pods             = 110
+  os_disk_size_gb      = 100
+
+  upgrade_settings {
+    max_surge = "2"
+  }
 
   tags = local.common_tags
 }

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -18,9 +18,10 @@ module "k8s_common" {
   gdcn_license_key       = var.gdcn_license_key
   gdcn_orgs              = var.gdcn_orgs
   gdcn_helm_extra_values = var.gdcn_helm_extra_values
-  size_profile           = var.size_profile
-  # There is no prod-large StarRocks profile; fall back to prod-xl sizing.
-  starrocks_size_profile = var.size_profile == "prod-large" ? "prod-xl" : var.size_profile
+  ingress_replicas       = local.profile.ingress_replicas
+  gdcn_size              = local.profile.gdcn_size
+  pulsar_size            = local.profile.pulsar_size
+  observability_size     = local.profile.observability_size
   cloud                  = "azure"
   ingress_controller     = var.ingress_controller
 

--- a/azure/postgresql.tf
+++ b/azure/postgresql.tf
@@ -11,6 +11,7 @@ resource "random_password" "db_password" {
 locals {
   db_username = "postgres"
   db_password = random_password.db_password.result
+  # PostgreSQL sizing resolved in size-profiles.tf.
 }
 
 # Create Private DNS Zone for PostgreSQL
@@ -42,8 +43,8 @@ resource "azurerm_postgresql_flexible_server" "main" {
   private_dns_zone_id    = azurerm_private_dns_zone.postgresql.id
   administrator_login    = local.db_username
   administrator_password = local.db_password
-  storage_mb             = var.postgresql_storage_mb
-  sku_name               = var.postgresql_sku_name
+  storage_mb             = local.postgresql_storage_mb
+  sku_name               = local.postgresql_sku_name
 
   # Disable public network access when using VNet integration
   public_network_access_enabled = false
@@ -74,4 +75,19 @@ resource "azurerm_postgresql_flexible_server_configuration" "trigram" {
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.main.id
   value     = "PG_TRGM"
+}
+
+# Performance parameters tuned by size_profile (see size-profiles.tf). Both are
+# dynamic (no restart). shared_buffers/effective_cache_size are left to the SKU
+# defaults, which scale with instance memory. Values are in kB.
+resource "azurerm_postgresql_flexible_server_configuration" "work_mem" {
+  name      = "work_mem"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = tostring(local.profile.postgres.work_mem_mb * 1024)
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "maintenance_work_mem" {
+  name      = "maintenance_work_mem"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = tostring(local.profile.postgres.maintenance_work_mem_mb * 1024)
 }

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -106,8 +106,9 @@ gdcn_orgs = [
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
 
-# Uncomment to override data retention (defaults shown). Each signal has its own 5Gi
-# PVC, so lower these to bound storage. Loki must be a multiple of 24h.
+# Uncomment to override data retention (defaults shown). Each signal has its own
+# PVC sized by size_profile (5Gi dev / 10Gi prod-small / 20Gi prod-large), so
+# lower these to bound storage. Loki must be a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
 # tempo_retention_period      = "168h"

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -1,7 +1,7 @@
 ###
 # Azure subscription & location
 ###
-# Set if you want to override the subscription/tenant from `az login`.
+# Uncomment to override the subscription/tenant from `az login`.
 # Otherwise, Terraform uses your current Azure CLI session.
 # azure_subscription_id = "00000000-0000-0000-0000-000000000000"
 # azure_tenant_id       = "00000000-0000-0000-0000-000000000000"
@@ -9,7 +9,7 @@
 # Region to deploy resources to
 azure_location = "East US"
 
-# Additional tags to apply to all Azure resources
+# Uncomment to apply additional tags to all Azure resources
 # azure_additional_tags = {
 #   Environment = "dev"
 # }
@@ -23,24 +23,29 @@ deployment_name   = "gooddata-cn"
 # GoodData.CN license key
 gdcn_license_key = "key/asdf==" # provided by GoodData
 
-# Additional gooddata-cn Helm values
+# Uncomment to append extra gooddata-cn Helm values
 # gdcn_helm_extra_values = <<-EOT
 #   service:
 #     someComponent:
 #       replicaCount: 3
 # EOT
 
-# Deploys and enables GoodData generative AI services
+# Uncomment to deploy and enable GoodData generative AI services
 # enable_ai_features = true
 
-# Enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
+# Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
 
-# Size profile controls replicas/resources across services:
+# Size profile:
 # - dev: lowest footprint, not HA
-# - prod-small: HA (>= 2 replica per service), resources for services increased
-# NOTE: switching size profile after deploying isn't supported since persistent
-# volume sizes can't be automatically adjusted in-place.
+# - prod-small: HA (>= 2 replicas per service), increased resources
+# - prod-large: HA, sized for large/high-traffic deployments
+# It sets sensible defaults for the metadata DB tier/storage, worker node
+# sizes/counts, observability disk sizes, and GoodData.CN/subchart sizing, so you
+# don't set those individually. To override one default, add its variable here
+# yourself (e.g. postgresql_sku_name, aks_node_vm_sizes); see variables.tf for the list.
+# NOTE: changing size_profile after deploying isn't supported (persistent volume
+# sizes can't be resized in place).
 size_profile = "prod-small"
 
 ###
@@ -59,7 +64,7 @@ ingress_controller = "ingress-nginx"
 tls_mode          = "letsencrypt"
 letsencrypt_email = "me@example.com"
 
-# When ingress-nginx sits behind another L7 proxy/load balancer, set this to true.
+# Uncomment when ingress-nginx sits behind another L7 proxy/load balancer.
 # ingress_nginx_behind_l7 = true
 
 # Option 2 — Istio Gateway + Let's Encrypt certificates (letsencrypt)
@@ -100,8 +105,8 @@ gdcn_orgs = [
 # Uncomment to enable the observability stack
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
-#
-# Observability data retention (optional; defaults shown). Each signal has its own 5Gi
+
+# Uncomment to override data retention (defaults shown). Each signal has its own 5Gi
 # PVC, so lower these to bound storage. Loki must be a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
@@ -116,13 +121,8 @@ gdcn_orgs = [
 # dockerhub_access_token = "myaccesstoken"
 
 ###
-# AKS & infrastructure sizing (optional)
+# AKS & infrastructure (optional)
 ###
+# Uncomment to override AKS defaults
 # aks_version                         = "1.35"
-# aks_node_vm_size                    = "Standard_D4as_v6"
-# aks_min_nodes                       = 2
-# aks_max_nodes                       = 10
 # aks_api_server_authorized_ip_ranges = ["x.x.x.x/32"]
-
-# postgresql_sku_name   = "GP_Standard_D2ds_v5"
-# postgresql_storage_mb = 32768

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -44,8 +44,8 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 # sizes/counts, observability disk sizes, and GoodData.CN/subchart sizing, so you
 # don't set those individually. To override one default, add its variable here
 # yourself (e.g. postgresql_sku_name, aks_node_vm_sizes); see variables.tf for the list.
-# NOTE: changing size_profile after deploying isn't supported (persistent volume
-# sizes can't be resized in place).
+# NOTE: changing size_profile after deploying isn't a supported migration; PVCs
+# can't shrink, and growing them is a manual, storage-class-dependent step.
 size_profile = "prod-small"
 
 ###

--- a/azure/size-profiles.tf
+++ b/azure/size-profiles.tf
@@ -1,0 +1,77 @@
+###
+# Single source of truth for Azure sizing per size_profile: managed infra
+# (PostgreSQL, AKS nodes, autoscaler bounds, ingress replicas) inline, plus
+# workload (GoodData.CN/Pulsar/observability) sizing referenced by name. prod-xl
+# is not valid on Azure. Override any managed value via the matching var.* input.
+###
+
+locals {
+  size_profiles = {
+    dev = {
+      postgresql = {
+        sku_name   = "B_Standard_B2s"
+        storage_mb = 32768
+      }
+      postgres = {
+        work_mem_mb             = 8
+        maintenance_work_mem_mb = 128
+      }
+      aks_node_vm_sizes = ["Standard_D4as_v6", "Standard_D2as_v6"]
+      aks_node_counts = {
+        min = 1
+        max = 6
+      }
+      ingress_replicas   = 1
+      gdcn_size          = "dev"
+      pulsar_size        = "dev"
+      observability_size = "dev"
+    }
+    prod-small = {
+      postgresql = {
+        sku_name   = "GP_Standard_D4ds_v5"
+        storage_mb = 131072
+      }
+      postgres = {
+        work_mem_mb             = 16
+        maintenance_work_mem_mb = 256
+      }
+      aks_node_vm_sizes = ["Standard_D4as_v6", "Standard_D2as_v6", "Standard_D8as_v6"]
+      aks_node_counts = {
+        min = 2
+        max = 12
+      }
+      ingress_replicas   = 2
+      gdcn_size          = "prod-small"
+      pulsar_size        = "prod-small"
+      observability_size = "prod-small"
+    }
+    prod-large = {
+      postgresql = {
+        sku_name   = "MO_Standard_E4ds_v5"
+        storage_mb = 131072
+      }
+      postgres = {
+        work_mem_mb             = 32
+        maintenance_work_mem_mb = 512
+      }
+      aks_node_vm_sizes = ["Standard_D4as_v6", "Standard_D2as_v6", "Standard_D8as_v6", "Standard_D16as_v6"]
+      aks_node_counts = {
+        min = 3
+        max = 20
+      }
+      ingress_replicas   = 3
+      gdcn_size          = "prod-large"
+      pulsar_size        = "prod-large"
+      observability_size = "prod-large"
+    }
+  }
+
+  profile = local.size_profiles[var.size_profile]
+
+  # Resolved managed values (profile default, overridable via var.*).
+  postgresql_sku_name   = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
+  postgresql_storage_mb = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
+  aks_node_vm_sizes     = coalesce(var.aks_node_vm_sizes, local.profile.aks_node_vm_sizes)
+  aks_min_nodes         = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
+  aks_max_nodes         = coalesce(var.aks_max_nodes, local.profile.aks_node_counts.max)
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -5,7 +5,7 @@ variable "aks_api_server_authorized_ip_ranges" {
 }
 
 variable "aks_max_nodes" {
-  description = "Maximum number of AKS worker nodes (autoscaler ceiling). If null, chosen by size_profile."
+  description = "Maximum worker nodes PER node pool (autoscaler ceiling applied to the default pool and to each additional aks_node_vm_sizes pool independently, so the cluster-wide max is this value times the number of pools). If null, chosen by size_profile."
   type        = number
   default     = null
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -5,21 +5,26 @@ variable "aks_api_server_authorized_ip_ranges" {
 }
 
 variable "aks_max_nodes" {
-  description = "Maximum number of AKS worker nodes"
+  description = "Maximum number of AKS worker nodes (autoscaler ceiling). If null, chosen by size_profile."
   type        = number
-  default     = 20
+  default     = null
 }
 
 variable "aks_min_nodes" {
-  description = "Minimum number of AKS worker nodes"
+  description = "Minimum number of AKS worker nodes. If null, chosen by size_profile."
   type        = number
-  default     = 2
+  default     = null
 }
 
-variable "aks_node_vm_size" {
-  description = "VM size for AKS worker nodes. E.g. Standard_D4as_v6, Standard_D4pd_v6"
-  type        = string
-  default     = "Standard_D4as_v6"
+variable "aks_node_vm_sizes" {
+  description = "VM sizes for AKS worker pools. The first entry sizes the default (system) node pool; any additional entries each create a separate autoscaling user node pool (scaling from 0). With least-waste autoscaling this lets the cluster pick the cheapest size that fits pending pods, mirroring the AWS eks_node_types list. If null, chosen by size_profile. E.g. [\"Standard_D4as_v6\", \"Standard_D8as_v6\", \"Standard_D16as_v6\"]."
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition     = var.aks_node_vm_sizes == null || length(var.aks_node_vm_sizes) > 0
+    error_message = "aks_node_vm_sizes must contain at least one VM size (the default node pool)."
+  }
 }
 
 variable "aks_version" {
@@ -322,15 +327,15 @@ variable "observability_hostname" {
 }
 
 variable "postgresql_sku_name" {
-  description = "Azure Database for PostgreSQL SKU name. E.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3"
+  description = "Azure Database for PostgreSQL SKU name. If null, chosen by size_profile. E.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3"
   type        = string
-  default     = "GP_Standard_D2ds_v5"
+  default     = null
 }
 
 variable "postgresql_storage_mb" {
-  description = "Azure Database for PostgreSQL storage in MB"
+  description = "Azure Database for PostgreSQL storage in MB. If null, chosen by size_profile."
   type        = number
-  default     = 32768
+  default     = null
 }
 
 variable "size_profile" {

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -51,6 +51,7 @@ module "k8s_local" {
   enable_istio_injection = var.ingress_controller == "istio_gateway"
   enable_observability   = var.enable_observability
   helm_cnpg_version      = var.helm_cnpg_version
+  cnpg                   = local.profile.cnpg
   db_username            = local.local_db_username
   db_password            = random_password.local_postgres_password.result
   kubeconfig_path        = local.kubeconfig_path
@@ -75,15 +76,16 @@ module "k8s_common" {
     external   = external
   }
 
-  deployment_name  = var.deployment_name
-  gdcn_license_key = var.gdcn_license_key
-  gdcn_namespace   = var.gdcn_namespace
-  gdcn_orgs        = var.gdcn_orgs
-  size_profile     = var.size_profile
-  # There is no prod-large StarRocks profile; fall back to prod-xl sizing.
-  starrocks_size_profile = coalesce(var.starrocks_size_profile, var.size_profile == "prod-large" ? "prod-xl" : var.size_profile)
-  cloud                  = "local"
-  ingress_controller     = var.ingress_controller
+  deployment_name    = var.deployment_name
+  gdcn_license_key   = var.gdcn_license_key
+  gdcn_namespace     = var.gdcn_namespace
+  gdcn_orgs          = var.gdcn_orgs
+  ingress_replicas   = local.profile.ingress_replicas
+  gdcn_size          = local.profile.gdcn_size
+  pulsar_size        = local.profile.pulsar_size
+  observability_size = local.profile.observability_size
+  cloud              = "local"
+  ingress_controller = var.ingress_controller
 
   letsencrypt_email       = ""
   auth_hostname           = var.auth_hostname

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -10,8 +10,8 @@ deployment_name = "gooddata-cn-local"
 ###
 k3d_cluster_name = "gdcluster"
 
-# If you're running Terraform on a Linux host (not inside a container) and
-# host.docker.internal is not resolvable, set:
+# Uncomment if you're running Terraform on a Linux host (not inside a container)
+# and host.docker.internal is not resolvable:
 # k3d_kubeapi_host = "127.0.0.1"
 
 ###
@@ -22,23 +22,22 @@ helm_gdcn_version = "4.10.0" # use latest version here: https://www.gooddata.com
 # GoodData.CN license key
 gdcn_license_key = "key/asdf==" # provided by GoodData
 
-# Additional gooddata-cn Helm values
+# Uncomment to append extra gooddata-cn Helm values
 # gdcn_helm_extra_values = <<-EOT
 #   service:
 #     someComponent:
 #       replicaCount: 3
 # EOT
 
-# Deploys and enables GoodData generative AI services
+# Uncomment to deploy and enable GoodData generative AI services
 # enable_ai_features = true
 
-# Enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
+# Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
 
-# Size profile controls replicas/resources across services:
-# - dev: lowest footprint, not HA
-# NOTE: switching size profile after deploying isn't supported since persistent
-# volume sizes can't be automatically adjusted in-place.
+# Size profile controls replicas/resources across services plus the in-cluster
+# metadata postgres sizing. Local installs only support "dev" (the smallest,
+# non-HA footprint).
 size_profile = "dev"
 
 ###
@@ -86,8 +85,8 @@ gdcn_orgs = [
 # Uncomment to enable the observability stack
 # enable_observability = true
 # observability_hostname = "observability.localhost"
-#
-# Observability data retention (optional; defaults shown). Each signal has its own 5Gi
+
+# Uncomment to override data retention (defaults shown). Each signal has its own 5Gi
 # PVC, so lower these to bound storage. Loki must be a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"

--- a/local/size-profiles.tf
+++ b/local/size-profiles.tf
@@ -1,0 +1,27 @@
+###
+# Single source of truth for local (k3d) sizing. Local supports only "dev"
+# (smallest, non-HA). Holds the in-cluster postgres (CNPG) sizing inline plus
+# workload (GoodData.CN/Pulsar/observability) sizing referenced by name.
+# StarRocks (AI Lake) is not supported on local.
+###
+
+locals {
+  size_profiles = {
+    dev = {
+      cnpg = {
+        cpu                     = "200m"
+        instances               = 1
+        maintenance_work_mem_mb = 128
+        memory                  = "256Mi"
+        storage                 = "2Gi"
+        work_mem_mb             = 8
+      }
+      ingress_replicas   = 1
+      gdcn_size          = "dev"
+      pulsar_size        = "dev"
+      observability_size = "dev"
+    }
+  }
+
+  profile = local.size_profiles[var.size_profile]
+}

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -295,24 +295,15 @@ variable "registry_quayio" {
 }
 
 variable "size_profile" {
-  description = "Sizing profile for GoodData.CN and supporting services."
+  description = "Sizing profile for GoodData.CN and supporting services. Local installs only support \"dev\"."
   type        = string
   default     = "dev"
   validation {
-    condition     = contains(["dev", "prod-small", "prod-large"], var.size_profile)
-    error_message = "size_profile must be one of: dev, prod-small, prod-large."
+    condition     = contains(["dev"], var.size_profile)
+    error_message = "size_profile must be \"dev\" for local installs."
   }
 }
 
-variable "starrocks_size_profile" {
-  description = "Sizing profile for StarRocks (FE/CN pods). If null, falls back to size_profile."
-  type        = string
-  default     = null
-  validation {
-    condition     = var.starrocks_size_profile == null || contains(["dev"], coalesce(var.starrocks_size_profile, "dev"))
-    error_message = "starrocks_size_profile must be \"dev\" for local installs."
-  }
-}
 
 variable "tls_mode" {
   description = "TLS management mode for local installs. Use selfsigned for cert-manager self-signed certificates."

--- a/modules/k8s-aws/lb-controller.tf
+++ b/modules/k8s-aws/lb-controller.tf
@@ -268,7 +268,7 @@ resource "helm_release" "aws_load_balancer_controller" {
   timeout       = 1800
 
   values = [<<EOF
-    replicaCount: ${var.size_profile == "dev" ? 1 : 2}
+    replicaCount: ${var.ingress_replicas}
     clusterName: ${var.deployment_name}
     region: ${var.aws_region}
     vpcId: ${var.vpc_id}

--- a/modules/k8s-aws/variables.tf
+++ b/modules/k8s-aws/variables.tf
@@ -22,6 +22,6 @@ variable "registry_k8sio" { type = string }
 
 variable "route53_zone_id" { type = string }
 
-variable "size_profile" { type = string }
+variable "ingress_replicas" { type = number }
 
 variable "vpc_id" { type = string }

--- a/modules/k8s-aws/variables.tf
+++ b/modules/k8s-aws/variables.tf
@@ -18,10 +18,10 @@ variable "helm_metrics_server_version" { type = string }
 
 variable "ingress_controller" { type = string }
 
+variable "ingress_replicas" { type = number }
+
 variable "registry_k8sio" { type = string }
 
 variable "route53_zone_id" { type = string }
-
-variable "ingress_replicas" { type = number }
 
 variable "vpc_id" { type = string }

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -188,7 +188,7 @@ resource "helm_release" "gooddata_cn" {
       s3_datasource_fs_bucket = var.local_s3_datasource_fs_bucket
       s3_quiver_cache_bucket  = var.local_s3_quiver_cache_bucket
     }) : null,
-    templatefile("${path.module}/templates/gdcn-size-${local.size_profile_template}.yaml.tftpl", {}),
+    templatefile("${path.module}/templates/gdcn-size-${var.gdcn_size}.yaml.tftpl", {}),
     var.gdcn_helm_extra_values != "" ? var.gdcn_helm_extra_values : null,
   ])
 

--- a/modules/k8s-common/ingress.tf
+++ b/modules/k8s-common/ingress.tf
@@ -6,7 +6,7 @@ locals {
   ingress_values = {
     controller = merge(
       {
-        replicaCount = var.size_profile == "dev" ? 1 : 2
+        replicaCount = var.ingress_replicas
         image = {
           registry = var.registry_k8sio
         }

--- a/modules/k8s-common/locals.tf
+++ b/modules/k8s-common/locals.tf
@@ -14,10 +14,6 @@ locals {
 
   cert_manager_cluster_issuer_name = local.use_self_signed ? "selfsigned" : "letsencrypt"
 
-  # GoodData.CN and Pulsar have no dedicated prod-xl sizing template; prod-xl
-  # reuses prod-large (matching the observability sizing in observability.tf).
-  size_profile_template = var.size_profile == "prod-xl" ? "prod-large" : var.size_profile
-
   # Reuse a single ingress class name throughout the module
   resolved_ingress_class_name = var.ingress_controller == "alb" ? "alb" : (
     var.ingress_controller == "istio_gateway" ? "" : "nginx"

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -133,8 +133,9 @@ resource "helm_release" "loki" {
           }]
         }
         # Retention is enforced by the compactor loop below. retention_period
-        # caps log age; the 5Gi PVC still caps total size, so at high log volume
-        # data may be evicted before this period is reached.
+        # caps log age; the PVC (size set per tier in size-profiles.tf) still
+        # caps total size, so at high log volume data may be evicted before this
+        # period is reached.
         limits_config = {
           retention_period = var.loki_retention_period
         }
@@ -254,8 +255,9 @@ resource "helm_release" "tempo" {
           }
           zipkin = { endpoint = "0.0.0.0:9411" }
         }
-        # Trace retention enforced by the block-storage compactor. The 5Gi PVC
-        # still caps total size, so traces may be evicted before this period.
+        # Trace retention enforced by the block-storage compactor. The PVC (size
+        # set per tier in size-profiles.tf) still caps total size, so traces may
+        # be evicted before this period.
         retention = var.tempo_retention_period
         # Per-tenant ingestion limits, sized by tier (see size-profiles.tf).
         # Strategy stays "local" (single-binary deployment, no global ring).

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -10,43 +10,7 @@ resource "kubernetes_namespace_v1" "observability" {
 }
 
 locals {
-  # Memory requests/limits for the observability stack, scaled by size_profile.
-  # CPU is intentionally left flat per-service (these components are memory-bound,
-  # not CPU-bound, at our scale).
-  observability_memory = {
-    dev = {
-      prometheus = { request = "256Mi", limit = "1Gi" }
-      loki       = { request = "256Mi", limit = "1Gi" }
-      tempo      = { request = "128Mi", limit = "512Mi" }
-      grafana    = { request = "128Mi", limit = "512Mi" }
-      promtail   = { request = "64Mi", limit = "256Mi" }
-    }
-    prod-small = {
-      prometheus = { request = "512Mi", limit = "2Gi" }
-      loki       = { request = "512Mi", limit = "2Gi" }
-      tempo      = { request = "256Mi", limit = "1Gi" }
-      grafana    = { request = "256Mi", limit = "1Gi" }
-      promtail   = { request = "128Mi", limit = "256Mi" }
-    }
-    prod-large = {
-      prometheus = { request = "1Gi", limit = "4Gi" }
-      loki       = { request = "1Gi", limit = "4Gi" }
-      # Higher request/limit gives the single-binary Tempo headroom for the
-      # raised ingestion limits (see helm_release.tempo overrides) so the
-      # larger live-trace buffer does not OOM under peak trace volume.
-      tempo    = { request = "1Gi", limit = "3Gi" }
-      grafana  = { request = "256Mi", limit = "1Gi" }
-      promtail = { request = "128Mi", limit = "512Mi" }
-    }
-  }
-
-  # size_profile_template already maps prod-xl to prod-large; any other unmapped
-  # profile falls back to prod-small.
-  obs_mem = lookup(
-    local.observability_memory,
-    local.size_profile_template,
-    local.observability_memory["prod-small"],
-  )
+  # Observability sizing (obs_mem / obs_disk) lives in size-profiles.tf.
 
   # dotdc Kubernetes dashboards loaded into Grafana (see dashboards block below).
   grafana_kubernetes_dashboards = [
@@ -117,7 +81,7 @@ resource "helm_release" "kube_prometheus_stack" {
             volumeClaimTemplate = {
               spec = {
                 resources = {
-                  requests = { storage = "5Gi" }
+                  requests = { storage = local.obs_disk.prometheus }
                 }
               }
             }
@@ -184,7 +148,7 @@ resource "helm_release" "loki" {
         replicas = 1
         persistence = {
           enabled = true
-          size    = "5Gi"
+          size    = local.obs_disk.loki
         }
         resources = {
           requests = {
@@ -293,22 +257,20 @@ resource "helm_release" "tempo" {
         # Trace retention enforced by the block-storage compactor. The 5Gi PVC
         # still caps total size, so traces may be evicted before this period.
         retention = var.tempo_retention_period
-        # Raise per-tenant ingestion limits above Tempo's defaults (15MB/s rate,
-        # 20MB burst). The defaults were rejecting trace pushes during peak
-        # windows with "RATE_LIMITED: ingestion rate limit ... exceeded" errors.
+        # Per-tenant ingestion limits, sized by tier (see size-profiles.tf).
         # Strategy stays "local" (single-binary deployment, no global ring).
         overrides = {
           defaults = {
             ingestion = {
-              rate_limit_bytes = 30000000 # 30 MB/s (default: 15 MB/s)
-              burst_size_bytes = 45000000 # 45 MB   (default: 20 MB)
+              rate_limit_bytes = local.obs_tempo_ingestion.rate_limit_bytes
+              burst_size_bytes = local.obs_tempo_ingestion.burst_size_bytes
             }
           }
         }
       }
       persistence = {
         enabled = true
-        size    = "5Gi"
+        size    = local.obs_disk.tempo
       }
       resources = {
         requests = {

--- a/modules/k8s-common/pulsar.tf
+++ b/modules/k8s-common/pulsar.tf
@@ -48,7 +48,7 @@ resource "helm_release" "pulsar" {
       enable_observability = var.enable_observability
     }),
     local.use_istio_gateway ? templatefile("${path.module}/templates/pulsar-istio.tftpl", {}) : null,
-    templatefile("${path.module}/templates/pulsar-size-${local.size_profile_template}.yaml.tftpl", {})
+    templatefile("${path.module}/templates/pulsar-size-${var.pulsar_size}.yaml.tftpl", {})
   ])
 
   depends_on = [

--- a/modules/k8s-common/size-profiles.tf
+++ b/modules/k8s-common/size-profiles.tf
@@ -1,0 +1,89 @@
+###
+# Cloud-agnostic workload sizing for the shared module. These values are the
+# same across AWS/Azure/local at a given tier, so they live here once and each
+# environment's size-profiles.tf selects a tier by name (var.observability_size,
+# var.gdcn_size, var.pulsar_size, var.starrocks_size_profile). GoodData.CN /
+# Pulsar / StarRocks sizing is in templates/*-size-<tier>.yaml.tftpl; the
+# observability stack (no per-tier Helm chart) is sized here.
+#
+# Observability CPU is intentionally left flat per-service (these components are
+# memory-bound, not CPU-bound, at our scale). The disk values are StatefulSet
+# volumeClaimTemplates — immutable, so they apply only at PVC creation; a live
+# resize is a manual operation and shrinking is never supported.
+###
+
+locals {
+  # Keyed by the tier the environment passes as var.observability_size.
+  size_profiles = {
+    dev = {
+      observability = {
+        memory = {
+          prometheus = { request = "256Mi", limit = "1Gi" }
+          loki       = { request = "256Mi", limit = "1Gi" }
+          tempo      = { request = "128Mi", limit = "512Mi" }
+          grafana    = { request = "128Mi", limit = "512Mi" }
+          promtail   = { request = "64Mi", limit = "256Mi" }
+        }
+        disk = {
+          prometheus = "5Gi"
+          loki       = "5Gi"
+          tempo      = "5Gi"
+        }
+        # Per-tenant Tempo trace-ingestion limits. dev uses Tempo's defaults.
+        tempo_ingestion = {
+          rate_limit_bytes = 15000000 # 15 MB/s
+          burst_size_bytes = 20000000 # 20 MB
+        }
+      }
+    }
+    prod-small = {
+      observability = {
+        memory = {
+          prometheus = { request = "512Mi", limit = "2Gi" }
+          loki       = { request = "512Mi", limit = "2Gi" }
+          tempo      = { request = "256Mi", limit = "1Gi" }
+          grafana    = { request = "256Mi", limit = "1Gi" }
+          promtail   = { request = "128Mi", limit = "256Mi" }
+        }
+        disk = {
+          prometheus = "10Gi"
+          loki       = "10Gi"
+          tempo      = "10Gi"
+        }
+        # Raised above Tempo defaults to stop RATE_LIMITED drops at peak.
+        tempo_ingestion = {
+          rate_limit_bytes = 30000000 # 30 MB/s
+          burst_size_bytes = 45000000 # 45 MB
+        }
+      }
+    }
+    prod-large = {
+      observability = {
+        memory = {
+          prometheus = { request = "1Gi", limit = "4Gi" }
+          loki       = { request = "1Gi", limit = "4Gi" }
+          # Higher request/limit gives the single-binary Tempo headroom for the
+          # raised ingestion limits below, so the larger live-trace buffer does
+          # not OOM under peak trace volume.
+          tempo    = { request = "1Gi", limit = "3Gi" }
+          grafana  = { request = "256Mi", limit = "1Gi" }
+          promtail = { request = "128Mi", limit = "512Mi" }
+        }
+        disk = {
+          prometheus = "20Gi"
+          loki       = "20Gi"
+          tempo      = "20Gi"
+        }
+        tempo_ingestion = {
+          rate_limit_bytes = 50000000 # 50 MB/s
+          burst_size_bytes = 75000000 # 75 MB
+        }
+      }
+    }
+  }
+
+  profile             = local.size_profiles[var.observability_size]
+  obs_mem             = local.profile.observability.memory
+  obs_disk            = local.profile.observability.disk
+  obs_tempo_ingestion = local.profile.observability.tempo_ingestion
+}

--- a/modules/k8s-common/templates/gdcn-size-dev.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-dev.yaml.tftpl
@@ -16,8 +16,10 @@ redis-ha:
   persistentVolume:
     size: 1Gi
 
-etcd:
+customEtcd:
   replicaCount: 1
+  antiAffinity:
+    enabled: false
   persistence:
     size: 1Gi
 

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -1,15 +1,10 @@
-# Apply GoodData.CN "prod-large" size profile
-# last updated: 2026-06-05
+# GoodData.CN "prod-large" size profile (last updated: 2026-06-05)
 #
-# Large production sizing profile, modeled on a high-traffic multi-tenant
-# GoodData.CN deployment. Compared to prod-small it runs more replicas of the
-# hot-path services (metadataApi, sqlExecutor, calcique, afmExecApi,
-# visualExporter, export-builder) and gives them substantially more CPU/memory,
-# enables dedicated Quiver policy nodes, and uses a larger result cache.
+# High-traffic multi-tenant sizing: more hot-path replicas + CPU/memory than
+# prod-small, dedicated Quiver policy nodes, larger result cache.
 #
-# NOTE on StarRocks (AI Lake): there is no prod-large StarRocks profile. When
-# size_profile = "prod-large" the StarRocks sizing falls back to prod-xl. Set
-# var.starrocks_size_profile explicitly if you want different StarRocks sizing.
+# StarRocks (AI Lake) is sized separately via var.starrocks_size_profile
+# (dev/prod-small/prod-xl); it is not derived from this profile.
 
 replicaCount: 2
 
@@ -34,13 +29,10 @@ deployQuiverDatasourceFs: true
 useInternalGDEtcd: true
 
 afmExecApi:
-  # Reactive (Netty/WebFlux); blocking downstream calls run on the Kotlin
-  # Dispatchers.IO pool, whose 64-thread default caps each pod at ~50 concurrent
-  # requests regardless of CPU. Raise io.parallelism + ActiveProcessorCount to
-  # lift per-pod concurrency, and scale out.
+  # Netty/WebFlux: blocking calls use Dispatchers.IO (64-thread default caps
+  # ~50 req/pod). io.parallelism + ActiveProcessorCount raise per-pod concurrency.
   jvmOptions: -Xmx1700M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=200M -XX:ActiveProcessorCount=8 -Dkotlinx.coroutines.io.parallelism=128
-  # 8 replicas: trimming to 4 regressed execute latency ~80ms->5s at 40 loads/s;
-  # the gateway feeds ~1600 concurrent forwards that need this many dispatchers.
+  # 8 replicas: 4 regressed execute latency ~80ms->5s at 40 loads/s.
   replicaCount: 8
   resources:
     limits:
@@ -86,8 +78,7 @@ authService:
       cpu: 100m
       memory: 820Mi
 automation:
-  # Disable the dead Zipkin exporter (see metadataApi); otherwise it throttles
-  # span export and drops traces under load.
+  # Disable the dead Zipkin exporter (see metadataApi).
   extraEnvVars:
     - name: MANAGEMENT_ZIPKIN_TRACING_EXPORT_ENABLED
       value: "false"
@@ -103,11 +94,9 @@ calcique:
       memory: 2800Mi
 customEtcd:
   enabled: true
-  # 3-node coordination layer for the whole Quiver cluster (~20 pods register
-  # flights on every DoPut). The flight catalog plus large range-scan buffers
-  # (5000-key/~1.3MB reads) OOMKilled members at the old 1536Mi limit, losing
-  # quorum and blocking all flight writes. Fix is VERTICAL (more memory + CPU):
-  # etcd is Raft, so a 5th member only enlarges the write quorum. Stay at 3.
+  # 3-node Quiver coordination layer. Large range-scan buffers OOMKilled members
+  # at the old 1536Mi limit, losing quorum. Fix is vertical (more memory/CPU);
+  # etcd is Raft, so adding members only enlarges the write quorum. Stay at 3.
   resources:
     requests:
       cpu: 500m
@@ -188,20 +177,16 @@ measureEditor:
       cpu: 20m
       memory: 15Mi
 metadataApi:
-  # io.parallelism=16 saturates the JDBC pool first (16 blocking coroutine
-  # threads == 16 busy connections), pinning hikaricp_connections_active at the
-  # default max-pool-size=16 while gRPC latency climbs to ~1s at <1 CPU core.
-  # Raise the pool and io.parallelism together; the metadata RDS (~420 max
-  # connections on db.t4g.medium) has room for 4 pods x 48 burst.
+  # io.parallelism must rise with the Hikari pool: each blocking coroutine thread
+  # holds a connection, so io.parallelism=16 pins the pool at the default 16 and
+  # gRPC latency climbs to ~1s. 4 pods x 48 fits the RDS connection ceiling.
   extraEnvVars:
     - name: SPRING_DATASOURCE_HIKARI_MAXIMUMPOOLSIZE
       value: "48"
     - name: SPRING_DATASOURCE_HIKARI_MINIMUMIDLE
       value: "8"
-    # This image does not disable the auto-configured Zipkin exporter, so every
-    # span batch retries localhost:9411 (refused), throttling the export worker
-    # until it drops spans under load — why slow-request traces were missing
-    # downstream spans in Tempo.
+    # Disable the auto-configured Zipkin exporter: it retries localhost:9411 and
+    # throttles span export, dropping downstream spans from Tempo under load.
     - name: MANAGEMENT_ZIPKIN_TRACING_EXPORT_ENABLED
       value: "false"
   jvmOptions: -Xmx6000M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=128M -XX:ActiveProcessorCount=6 -Dkotlinx.coroutines.io.parallelism=48
@@ -246,43 +231,30 @@ qdrant:
       memory: 3500Mi
 quiver:
   limitFlightCount: 90000
-  # Cache-miss write-path gate: sql-executor streams results into quiver-cache
-  # via DoPut, and each put is bounded by these two limits. When they pinned,
-  # sql-executor's fetch blocked ~6s/query waiting for a put slot (RDS itself
-  # ran in 1ms), backing up sql.select by thousands of messages. Size puts and
-  # durable S3 writes well above the sustained cache-miss rate.
+  # Cache-miss write gate: sql-executor DoPuts results into quiver-cache, bounded
+  # by these limits. Too low, fetch blocked ~6s/query waiting for a put slot.
+  # Keep puts + durable S3 writes above the sustained cache-miss rate.
   concurrentPutRequests: 64
   s3DurableStorage:
     durableS3WritesInProgress: 128
   storage:
-    # The server work dir stores the flight catalog (SQLite database); as the
-    # total flight limit grows the workdir must be large enough to hold it.
+    # Holds the flight catalog (SQLite); must scale with limitFlightCount.
     serverWorkDirSize: 512Mi
     cache:
       diskCacheSize: 25Gi
       diskSize: 30Gi
   replicaCount:
-    # quiver-cache serves DoGet for every result fetch AND absorbs DoPut +
-    # durable S3 writes for every cache miss; two pods saturated their put
-    # pipeline under load while everything else idled.
+    # cache serves every DoGet + absorbs DoPut/S3 writes on cache miss; 2 pods
+    # saturated the put pipeline under load.
     cache: 4
-    # quiver-xtab (cross-tabulation) is I/O-bound — each task spends almost all
-    # its time on Flight input-I/O reading the source result from quiver-cache.
-    # 16 replicas, combined with the widened per-pod worker pools (see
-    # extraEnvVarsXtab below), clear the cross-tab queue at 40 loads/s.
+    # xtab is I/O-bound (Flight reads from cache). 16 pods + widened worker pools
+    # (extraEnvVarsXtab) clear the cross-tab queue at 40 loads/s.
     xtab: 16
   resources:
     cache:
-      # The mid-test collapse root cause: at peak write-rate the quiver-cache
-      # node serving this org's hot flight-cluster pins its CPU limit and its
-      # single-threaded etcd-view-apply loop falls behind the live revision.
-      # Flight reads carry an x-quiver-sync-rev consistency header, so once the
-      # local view lags, every read blocks 5s and times out
-      # (FlightTimedOutError "waited for local views to reach revision N") and
-      # retries — turning a 1.7ms cross-tab into a 9-14s stall and backing up
-      # result.xtab. The view-apply loop needs a full core even while flight
-      # serving / durable sync / reclaim threads are busy, so the 1.5-core limit
-      # starved it. Give cache real CPU headroom.
+      # Needs real CPU headroom: the single-threaded etcd-view-apply loop needs a
+      # full core, and starving it (old 1.5-core limit) made consistency-checked
+      # Flight reads block 5s and time out, stalling cross-tabs to 9-14s.
       limits:
         cpu: 4000m
         memory: 2048Mi
@@ -292,9 +264,8 @@ quiver:
         memory: 2048Mi
         ephemeral-storage: 30Gi
     xtab:
-      # CPU is bursty (8 worker subprocesses doing short polars ops), so headroom
-      # matters even though the 2-min-average CPU looks low. 4000m is the exact
-      # config from the p95<5s passing run.
+      # Bursty CPU (worker subprocesses run short polars ops); needs headroom
+      # despite low average. 4000m is the p95<5s passing config.
       limits:
         cpu: 4000m
         memory: 7680Mi
@@ -318,10 +289,8 @@ quiver:
   extraEnvVarsCache:
     - name: QUIVER_ETCD_NEW_EVENT_READER
       value: "1"
-    # durableS3WritesInProgress only caps admitted writes; the actual S3 uploads
-    # drain via storage_durable_sync_threads (default 4/pod). At sustained 40
-    # iter/s the buffer fills faster than 4 threads drain it and backpressures
-    # DoPut (and the whole cache-miss path). S3 PUTs are cheap I/O; widen the drain.
+    # S3 uploads drain via these threads (default 4/pod); at 40 iter/s 4 can't
+    # keep up and backpressure DoPut. S3 PUTs are cheap I/O, so widen the drain.
     - name: QUIVER_STORAGE_DURABLE_SYNC_THREADS
       value: "16"
   extraEnvVarsDatasource:
@@ -336,15 +305,10 @@ quiver:
   extraEnvVarsXtab:
     - name: QUIVER_ETCD_NEW_EVENT_READER
       value: "1"
-    # Per-pod cross-tab throughput is gated by these concurrency knobs, NOT by
-    # CPU or replica count. Each cross-tab task holds a worker ~0.15s but is
-    # almost entirely Flight I/O (read input result + write output); the polars
-    # compute is ~2ms, so pods sit at ~0.17 cores while task_workers=8 caps
-    # throughput at ~50/s/pod and tasks queue 20-30s under load. Because the
-    # work is I/O-bound with idle CPU and only ~1.5Gi of the 7.68Gi memory used,
-    # the right lever is more workers per pod (each worker is a subprocess
-    # ~180Mi), not more pods. Tripling the pools lifts per-pod throughput to
-    # ~150/s at trivial CPU cost; memory lands ~4.3Gi, well under the limit.
+    # Per-pod xtab throughput is gated by these worker pools, not CPU/replicas:
+    # tasks are ~I/O-bound (Flight), so pods idle at ~0.17 cores while the default
+    # 8 workers cap ~50/s/pod and queue 20-30s. Tripling lifts to ~150/s/pod at
+    # trivial CPU cost (memory ~4.3Gi, under the 7.68Gi limit).
     - name: QUIVER_DATAFRAME_TASK_THREADS
       value: "48"
     - name: QUIVER_DATAFRAME_TASK_WORKERS
@@ -396,14 +360,11 @@ redis-ha:
         memory: 64Mi
         cpu: 150m
 resultCache:
-  # Runs the execution plan for every AFM (even cache hits). It is Kotlin and
-  # sizes coroutine dispatchers from the processor count; with ActiveProcessorCount
-  # unset and io.parallelism=64, ~200 concurrent executions/pod contend for ~6
-  # Dispatchers.Default threads, taking ~4.7s instead of ~0.3s at ~23% CPU. That
-  # latency holds api-gw's forward pool open. Widen dispatchers and scale out.
+  # Runs the execution plan for every AFM. Kotlin sizes dispatchers from the CPU
+  # count; without ActiveProcessorCount ~200 executions/pod contend for ~6 threads
+  # (~4.7s vs ~0.3s), holding api-gw's forward pool open. Widen and scale out.
   jvmOptions: -Xmx2100M -XX:MaxMetaspaceSize=384M -XX:MaxDirectMemorySize=384M -XX:ActiveProcessorCount=8 -Dkotlinx.coroutines.io.parallelism=256
-  # 6 replicas @ 4000m: trimming to 4 / 2000m regressed execute latency
-  # ~80ms->5s at 40 loads/s (ActiveProcessorCount=8 needs the CPU limit to back it).
+  # 6 replicas @ 4000m: 4/2000m regressed execute latency ~80ms->5s at 40 loads/s.
   replicaCount: 6
   resources:
     limits:
@@ -418,8 +379,7 @@ resultCache:
       maxConcurrentMessages: 200
   # Large total result-cache size limit (512 GiB).
   totalCacheLimit: 549755813888
-  # Disable the dead Zipkin exporter (see metadataApi); otherwise it throttles
-  # span export and drops traces under load.
+  # Disable the dead Zipkin exporter (see metadataApi).
   extraEnvVars:
     - name: MANAGEMENT_ZIPKIN_TRACING_EXPORT_ENABLED
       value: "false"
@@ -434,14 +394,12 @@ scanModel:
       memory: 700Mi
 sqlExecutor:
   jvmOptions: -Xmx2048M -XX:MaxMetaspaceSize=256M -XX:MaxDirectMemorySize=512M -XX:ActiveProcessorCount=32
-  # sql-executor pods idle even at full load (the cache-miss gate is the
-  # quiver-cache put pipeline, since fixed); 8 pods x receiverQueueSize 6 = 48
-  # in-flight SQL, well above the sustained miss rate.
+  # Pods idle at full load (gated by quiver-cache puts); 8 x receiverQueueSize 6
+  # = 48 in-flight SQL, above the sustained miss rate.
   replicaCount: 8
   pulsar:
     sqlSelect:
-      # Match pre-fetch depth to pool size so a pod never accepts more work than
-      # it has JDBC connections for, avoiding a connection-exhaustion cascade.
+      # Match pre-fetch depth to the JDBC pool size to avoid connection exhaustion.
       receiverQueueSize: 6
   resources:
     limits:
@@ -517,17 +475,13 @@ exportBuilder:
       cpu: 200m
       memory: 550Mi
 apiGw:
-  # Ktor front-door gateway. Each request is forwarded over a Ktor CIO client
-  # whose per-route pool (~100 conns/pod, not exposed in the chart) holds a
-  # connection for the full backend execution, so forward concurrency = ~100 x
-  # replicas. This is the ceiling only when backends are slow (api-gw's own time
-  # stays ~1ms). Trimmed to 6 (~600 slots) to bisect a suspected trim regression;
-  # revert to 16 (the known-good baseline) if the gateway backs up under the
-  # load-test ramp. api-gw is CPU-cheap (~5%), so the replicas cost little either way.
+  # Ktor gateway. Each forward holds a CIO connection (~100/pod) for the full
+  # backend call, so forward concurrency = ~100 x replicas — the ceiling when
+  # backends are slow. 6 pods (~600 slots); raise toward 16 if it backs up.
   replicaCount: 6
   database:
     pool:
-      # Wider apiGw DB connection pool for higher concurrency (matches prod).
+      # Wider DB pool for higher concurrency (matches prod).
       maxSize: 32
       minIdle: 4
       maxAcquireTime: 30000
@@ -538,8 +492,6 @@ apiGw:
     requests:
       cpu: 1000m
       memory: 3000Mi
-  # Keep aligned with resources.limits.memory above.
-  # Note: -Dkotlinx.coroutines.io.parallelism was tried here and had zero effect —
-  # api-gw's forward path is async CIO, not Dispatchers.IO; the forward pool above
-  # is the relevant limit.
+  # io.parallelism has no effect here: the forward path is async CIO, not
+  # Dispatchers.IO; the CIO pool above is the limit. Keep aligned with limits.memory.
   jvmOptions: "-Xms1500m -Xmx1500m -XX:ActiveProcessorCount=8 -XX:MaxDirectMemorySize=512m"

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -104,6 +104,8 @@ customEtcd:
     limits:
       cpu: 2000m
       memory: 4096Mi
+  persistence:
+    size: 512Gi
 dashboards:
   resources:
     limits:

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -256,9 +256,20 @@ variable "starrocks_s3_bucket_id" {
   default = ""
 }
 
-variable "size_profile" { type = string }
+variable "ingress_replicas" { type = number }
 
-variable "starrocks_size_profile" { type = string }
+# Workload size selectors, resolved by each env's size-profiles.tf.
+variable "gdcn_size" { type = string }
+
+variable "observability_size" { type = string }
+
+variable "pulsar_size" { type = string }
+
+# Required only when enable_ai_lake is true (StarRocks is AWS-only); null otherwise.
+variable "starrocks_size_profile" {
+  type    = string
+  default = null
+}
 
 variable "starrocks_cn_image_tag" {
   type    = string

--- a/modules/k8s-local/postgres.tf
+++ b/modules/k8s-local/postgres.tf
@@ -66,7 +66,7 @@ resource "kubectl_manifest" "postgres_cluster" {
       namespace = kubernetes_namespace_v1.postgres.metadata[0].name
     }
     spec = {
-      instances             = 1
+      instances             = var.cnpg.instances
       imageName             = var.postgres_image
       primaryUpdateStrategy = "unsupervised"
       enableSuperuserAccess = true
@@ -75,7 +75,7 @@ resource "kubectl_manifest" "postgres_cluster" {
       }
 
       storage = {
-        size         = "2Gi"
+        size         = var.cnpg.storage
         storageClass = local.postgres_storage_class
       }
 
@@ -91,8 +91,8 @@ resource "kubectl_manifest" "postgres_cluster" {
 
       resources = {
         requests = {
-          cpu    = "200m"
-          memory = "256Mi"
+          cpu    = var.cnpg.cpu
+          memory = var.cnpg.memory
         }
       }
 
@@ -104,6 +104,11 @@ resource "kubectl_manifest" "postgres_cluster" {
         pg_hba = [
           "hostssl all all 0.0.0.0/0 scram-sha-256",
         ]
+        # Tuned by size_profile (see local/size-profiles.tf).
+        parameters = {
+          work_mem             = "${var.cnpg.work_mem_mb}MB"
+          maintenance_work_mem = "${var.cnpg.maintenance_work_mem_mb}MB"
+        }
       }
     }
   })

--- a/modules/k8s-local/variables.tf
+++ b/modules/k8s-local/variables.tf
@@ -1,3 +1,15 @@
+variable "cnpg" {
+  description = "In-cluster metadata postgres (CNPG) sizing; resolved by local/size-profiles.tf."
+  type = object({
+    cpu                     = string
+    instances               = number
+    maintenance_work_mem_mb = number
+    memory                  = string
+    storage                 = string
+    work_mem_mb             = number
+  })
+}
+
 variable "db_password" {
   description = "PostgreSQL superuser password for the in-cluster (CloudNativePG) database."
   type        = string
@@ -19,12 +31,6 @@ variable "enable_observability" {
   description = "Whether observability (Prometheus, Grafana, etc.) is enabled. Controls PodMonitor creation for CNPG and PostgreSQL."
   type        = bool
   default     = false
-}
-
-variable "prometheus_crds_ready" {
-  description = "Name of the prometheus-operator-crds helm release. When non-empty, CNPG operator PodMonitor is enabled. Used as a dependency hint to ensure CRDs exist before CNPG applies them."
-  type        = string
-  default     = ""
 }
 
 variable "helm_cnpg_version" {
@@ -57,6 +63,18 @@ variable "postgres_image" {
   default     = "ghcr.io/cloudnative-pg/postgresql:16.4"
 }
 
+variable "prometheus_crds_ready" {
+  description = "Name of the prometheus-operator-crds helm release. When non-empty, CNPG operator PodMonitor is enabled. Used as a dependency hint to ensure CRDs exist before CNPG applies them."
+  type        = string
+  default     = ""
+}
+
+variable "registry_dockerio" {
+  description = "Docker Hub registry prefix (e.g. docker.io or a pull-through cache)."
+  type        = string
+  default     = "docker.io"
+}
+
 variable "s3_region" {
   description = "Region value used by S3 clients. (SeaweedFS ignores this but some clients require it.)"
   type        = string
@@ -85,12 +103,6 @@ variable "seaweedfs_release_name" {
   description = "Helm release name for SeaweedFS."
   type        = string
   default     = "seaweedfs"
-}
-
-variable "registry_dockerio" {
-  description = "Docker Hub registry prefix (e.g. docker.io or a pull-through cache)."
-  type        = string
-  default     = "docker.io"
 }
 
 variable "seaweedfs_storage_class" {


### PR DESCRIPTION
Adds a `size-profiles.tf` to each environment root (`aws/`, `azure/`, `local/`) plus one in `modules/k8s-common`, giving a single place where `size_profile` maps to concrete sizing. Profiles cover managed infrastructure as well as workloads: database SKU/storage, Postgres `work_mem`/`maintenance_work_mem`, worker node types, autoscaler bounds, ingress replicas, and observability PVC sizes / Tempo ingestion limits. Each value stays overridable through its own `var.*` (defaults are `null`).

- Azure takes a list of VM sizes (`aks_node_vm_sizes`); entries past the first become scale-from-zero user pools, mirroring AWS `eks_node_types`.
- `starrocks_size_profile` is independent of `size_profile` and required when `enable_ai_lake` is true.
- `local` accepts only `dev`.

Based on master; #216 stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)