### PR TITLE
feat(observability): back Loki and Tempo with object storage

### DIFF
--- a/aws/irsa.tf
+++ b/aws/irsa.tf
@@ -59,6 +59,12 @@ data "aws_iam_policy_document" "observability_irsa_assume_role" {
         "system:serviceaccount:observability:tempo",
       ]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
   }
 }
 

--- a/aws/irsa.tf
+++ b/aws/irsa.tf
@@ -35,6 +35,46 @@ resource "aws_iam_role_policy_attachment" "gdcn_irsa_s3_access" {
 }
 
 ###
+# IAM role for observability (Loki + Tempo) service accounts (IRSA)
+###
+
+# One role assumed by both the loki and tempo service accounts in the
+# observability namespace. The EKS IRSA webhook injects the web-identity token
+# off the SA's eks.amazonaws.com/role-arn annotation (no pod label needed).
+data "aws_iam_policy_document" "observability_irsa_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values = [
+        "system:serviceaccount:observability:loki",
+        "system:serviceaccount:observability:tempo",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "observability_irsa" {
+  name               = "${var.deployment_name}-observability-irsa"
+  assume_role_policy = data.aws_iam_policy_document.observability_irsa_assume_role.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "observability_irsa_s3_access" {
+  role       = aws_iam_role.observability_irsa.name
+  policy_arn = aws_iam_policy.observability_s3_access.arn
+}
+
+###
 # IAM role for StarRocks service account (IRSA)
 ###
 

--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -89,6 +89,38 @@ module "k8s_common" {
   prometheus_retention_period = var.prometheus_retention_period
   tempo_retention_period      = var.tempo_retention_period
 
+  # Observability object storage: Loki + Tempo write to S3 (no big PVC),
+  # authenticating via IRSA (observability IAM role assumed by their SAs).
+  loki_objstore = {
+    object_store = "s3"
+    storage = {
+      type = "s3"
+      # The SingleBinary chart references all three bucket names even with
+      # ruler/admin features off; point them at the one loki bucket.
+      bucketNames = {
+        chunks = aws_s3_bucket.observability["loki"].id
+        ruler  = aws_s3_bucket.observability["loki"].id
+        admin  = aws_s3_bucket.observability["loki"].id
+      }
+      # IRSA supplies credentials; only the region is needed (default endpoint).
+      s3 = {
+        region = var.aws_region
+      }
+    }
+  }
+  tempo_objstore = {
+    backend = "s3"
+    s3 = {
+      bucket   = aws_s3_bucket.observability["tempo"].id
+      endpoint = "s3.${var.aws_region}.amazonaws.com"
+      region   = var.aws_region
+    }
+    wal = { path = "/var/tempo/wal" }
+  }
+  obs_sa_annotations = {
+    "eks.amazonaws.com/role-arn" = aws_iam_role.observability_irsa.arn
+  }
+
   enable_ai_lake                        = var.enable_ai_lake
   starrocks_s3_bucket_id                = var.enable_ai_lake ? aws_s3_bucket.starrocks[0].id : ""
   starrocks_irsa_role_arn               = var.enable_ai_lake ? aws_iam_role.starrocks_irsa[0].arn : ""
@@ -124,6 +156,7 @@ module "k8s_common" {
     module.vpc,
     null_resource.alb_cleanup_wait,
     aws_iam_role_policy_attachment.gdcn_irsa_s3_access,
+    aws_iam_role_policy_attachment.observability_irsa_s3_access,
     aws_iam_role_policy_attachment.starrocks_irsa_s3_access,
     aws_iam_role_policy.ai_lake_pod_identity,
     aws_eks_pod_identity_association.ai_lake,

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -307,3 +307,91 @@ resource "aws_iam_policy" "gdcn_s3_access" {
     ]
   })
 }
+
+###
+# Observability S3 buckets (Loki chunks/index, Tempo trace blocks)
+###
+
+# Loki/Tempo store retention-sized data in S3 instead of large PVCs; the pods
+# keep only a small fixed WAL PVC. Kept separate from the GoodData.CN buckets so
+# the observability IRSA role grants access only to these two buckets.
+locals {
+  obs_s3_buckets = {
+    loki  = "-loki"
+    tempo = "-tempo"
+  }
+
+  obs_s3_bucket_arns = [for k in keys(local.obs_s3_buckets) : aws_s3_bucket.observability[k].arn]
+  obs_s3_object_arns = formatlist("%s/*", local.obs_s3_bucket_arns)
+}
+
+resource "aws_s3_bucket" "observability" {
+  for_each      = local.obs_s3_buckets
+  bucket        = substr("${local.bucket_prefix}${each.value}", 0, 63)
+  force_destroy = true
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "observability" {
+  for_each = aws_s3_bucket.observability
+  bucket   = each.value.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "observability" {
+  for_each = aws_s3_bucket.observability
+  bucket   = each.value.id
+
+  versioning_configuration {
+    status = "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "observability" {
+  for_each = aws_s3_bucket.observability
+  bucket   = each.value.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_iam_policy" "observability_s3_access" {
+  name        = "${var.deployment_name}-ObservabilityS3Access"
+  description = "Allow Loki and Tempo to use S3 buckets for object storage."
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowBucketListingAndLocation",
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:ListBucketMultipartUploads"
+        ],
+        Resource = local.obs_s3_bucket_arns
+      },
+      {
+        Sid    = "AllowObjectReadWriteAndMultipart",
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:AbortMultipartUpload",
+          "s3:ListMultipartUploadParts"
+        ],
+        Resource = local.obs_s3_object_arns
+      }
+    ]
+  })
+}

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -126,9 +126,8 @@ gdcn_orgs = [
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
 
-# Uncomment to override data retention (defaults shown). Each signal has its own
-# PVC sized by size_profile (5Gi dev / 10Gi prod-small / 20Gi prod-large), so
-# lower these to bound storage. Loki must be a multiple of 24h.
+# Uncomment to override data retention (defaults shown). Loki/Tempo store data
+# in S3, so retention bounds bucket usage. Loki needs a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
 # tempo_retention_period      = "168h"

--- a/azure/identity.tf
+++ b/azure/identity.tf
@@ -23,3 +23,40 @@ resource "azurerm_federated_identity_credential" "gdcn" {
   issuer                    = azurerm_kubernetes_cluster.main.oidc_issuer_url
   subject                   = "system:serviceaccount:${var.gdcn_namespace}:${local.gdcn_service_account_name}"
 }
+
+###
+# Workload Identity for observability (Loki + Tempo) -> Blob object storage.
+# One UAMI with Blob Data Contributor on the storage account, federated to the
+# loki and tempo service accounts in the observability namespace. Loki/Tempo
+# auth to Blob via the projected SA token (use_federated_token), no keys.
+###
+
+resource "azurerm_user_assigned_identity" "observability" {
+  name                = "${var.deployment_name}-obs-uami"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  tags = local.common_tags
+}
+
+resource "azurerm_role_assignment" "observability_blob_contrib" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.observability.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "loki" {
+  name                      = "loki-workload"
+  user_assigned_identity_id = azurerm_user_assigned_identity.observability.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject                   = "system:serviceaccount:observability:loki"
+}
+
+resource "azurerm_federated_identity_credential" "tempo" {
+  name                      = "tempo-workload"
+  user_assigned_identity_id = azurerm_user_assigned_identity.observability.id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject                   = "system:serviceaccount:observability:tempo"
+}

--- a/azure/identity.tf
+++ b/azure/identity.tf
@@ -26,9 +26,9 @@ resource "azurerm_federated_identity_credential" "gdcn" {
 
 ###
 # Workload Identity for observability (Loki + Tempo) -> Blob object storage.
-# One UAMI with Blob Data Contributor on the storage account, federated to the
-# loki and tempo service accounts in the observability namespace. Loki/Tempo
-# auth to Blob via the projected SA token (use_federated_token), no keys.
+# One UAMI federated to the loki and tempo service accounts in the observability
+# namespace. Loki/Tempo auth to Blob via the projected SA token
+# (use_federated_token), no keys.
 ###
 
 resource "azurerm_user_assigned_identity" "observability" {
@@ -39,8 +39,12 @@ resource "azurerm_user_assigned_identity" "observability" {
   tags = local.common_tags
 }
 
+# Scoped per container, not to the whole account, so observability pods cannot
+# reach the GoodData.CN containers (exports, quiver-cache, quiver-datasource-fs).
 resource "azurerm_role_assignment" "observability_blob_contrib" {
-  scope                = azurerm_storage_account.main.id
+  for_each = toset(local.observability_storage_containers)
+
+  scope                = azurerm_storage_container.containers[each.value].id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_user_assigned_identity.observability.principal_id
 }

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -66,6 +66,41 @@ module "k8s_common" {
   azure_datasource_fs_container = azurerm_storage_container.containers["quiver-datasource-fs"].name
   azure_uami_client_id          = azurerm_user_assigned_identity.gdcn.client_id
 
+  # Observability object storage: Loki + Tempo write to Blob (no big PVC),
+  # authenticating via workload identity (obs UAMI federated to their SAs).
+  loki_objstore = {
+    object_store = "azure"
+    storage = {
+      type = "azure"
+      # The SingleBinary chart references all three bucket names even with
+      # ruler/admin features off; point them at the one loki container.
+      bucketNames = {
+        chunks = azurerm_storage_container.containers["loki"].name
+        ruler  = azurerm_storage_container.containers["loki"].name
+        admin  = azurerm_storage_container.containers["loki"].name
+      }
+      azure = {
+        accountName       = azurerm_storage_account.main.name
+        useFederatedToken = true
+      }
+    }
+  }
+  tempo_objstore = {
+    backend = "azure"
+    azure = {
+      container_name       = azurerm_storage_container.containers["tempo"].name
+      storage_account_name = azurerm_storage_account.main.name
+      use_federated_token  = true
+    }
+    wal = { path = "/var/tempo/wal" }
+  }
+  obs_sa_annotations = {
+    "azure.workload.identity/client-id" = azurerm_user_assigned_identity.observability.client_id
+  }
+  obs_pod_labels = {
+    "azure.workload.identity/use" = "true"
+  }
+
   depends_on = [
     azurerm_kubernetes_cluster.main,
     # Storage classes + the default-class annotations must exist before any Helm
@@ -75,6 +110,10 @@ module "k8s_common" {
     kubernetes_annotations.default_storage_class,
     azurerm_role_assignment.gdcn_blob_contrib,
     azurerm_federated_identity_credential.gdcn,
+    # Observability Blob access must exist before Loki/Tempo start.
+    azurerm_role_assignment.observability_blob_contrib,
+    azurerm_federated_identity_credential.loki,
+    azurerm_federated_identity_credential.tempo,
     # Image cache plumbing must outlive the helm releases: pre-delete hooks
     # pull images via the cache rules, and kubelet needs AcrPull. Listing
     # these here makes destroy tear down k8s_common first, ACR plumbing after.

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -121,9 +121,8 @@ gdcn_orgs = [
 # enable_observability = true
 # observability_hostname = "observability.gooddata.example.com"
 
-# Uncomment to override data retention (defaults shown). Each signal has its own
-# PVC sized by size_profile (5Gi dev / 10Gi prod-small / 20Gi prod-large), so
-# lower these to bound storage. Loki must be a multiple of 24h.
+# Uncomment to override data retention (defaults shown). Loki/Tempo store data
+# in Azure Blob, so retention bounds container usage. Loki needs a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
 # tempo_retention_period      = "168h"

--- a/azure/storage.tf
+++ b/azure/storage.tf
@@ -19,15 +19,19 @@ locals {
   storage_account_prefix = substr(join("", regexall("[0-9a-z]", lower(var.deployment_name))), 0, 18)
   storage_account_name   = "${local.storage_account_prefix}${random_id.storage_suffix.hex}"
 
+  # Observability object storage (Loki chunks/index, Tempo trace blocks). Kept
+  # separate so the observability identity is scoped to just these containers.
+  observability_storage_containers = [
+    "loki",
+    "tempo",
+  ]
+
   # List of storage containers needed for GoodData.CN
-  storage_containers = [
+  storage_containers = concat([
     "quiver-cache",
     "quiver-datasource-fs",
     "exports",
-    # Observability object storage (Loki chunks/index, Tempo trace blocks).
-    "loki",
-    "tempo"
-  ]
+  ], local.observability_storage_containers)
 }
 
 resource "azurerm_storage_account" "main" {

--- a/azure/storage.tf
+++ b/azure/storage.tf
@@ -23,7 +23,10 @@ locals {
   storage_containers = [
     "quiver-cache",
     "quiver-datasource-fs",
-    "exports"
+    "exports",
+    # Observability object storage (Loki chunks/index, Tempo trace blocks).
+    "loki",
+    "tempo"
   ]
 }
 

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -62,6 +62,7 @@ module "k8s_local" {
   kubeconfig_path        = local.kubeconfig_path
   kubeconfig_context     = local.kubeconfig_context
   registry_dockerio      = var.registry_dockerio
+  seaweedfs_storage_size = var.seaweedfs_storage_size
 
   prometheus_crds_ready = helm_release.prometheus_operator_crds.name
 
@@ -123,7 +124,8 @@ module "k8s_common" {
 
   # Observability object storage: Loki + Tempo write to the local SeaweedFS S3
   # buckets instead of large PVCs. SeaweedFS has no workload identity, so static
-  # S3 credentials are passed; path-style + insecure (http) for the in-cluster
+  # S3 credentials are passed; each is a per-bucket SeaweedFS user, not the
+  # account-wide gdcn one. Path-style + insecure (http) for the in-cluster
   # endpoint. (obs_sa_annotations / obs_pod_labels stay empty — no IRSA/WI.)
   loki_objstore = {
     object_store = "s3"
@@ -139,8 +141,8 @@ module "k8s_common" {
       s3 = {
         endpoint         = local.local_obs_s3_endpoint_host
         region           = module.k8s_local.seaweedfs_region
-        accessKeyId      = module.k8s_local.seaweedfs_gdcn_access_key
-        secretAccessKey  = module.k8s_local.seaweedfs_gdcn_secret_key
+        accessKeyId      = module.k8s_local.seaweedfs_loki_access_key
+        secretAccessKey  = module.k8s_local.seaweedfs_loki_secret_key
         s3ForcePathStyle = true
         insecure         = true
       }
@@ -152,8 +154,8 @@ module "k8s_common" {
       bucket         = module.k8s_local.seaweedfs_bucket_tempo
       endpoint       = local.local_obs_s3_endpoint_host
       region         = module.k8s_local.seaweedfs_region
-      access_key     = module.k8s_local.seaweedfs_gdcn_access_key
-      secret_key     = module.k8s_local.seaweedfs_gdcn_secret_key
+      access_key     = module.k8s_local.seaweedfs_tempo_access_key
+      secret_key     = module.k8s_local.seaweedfs_tempo_secret_key
       forcepathstyle = true
       insecure       = true
     }

--- a/local/k8s-common.tf
+++ b/local/k8s-common.tf
@@ -7,6 +7,11 @@ locals {
   local_db_hostname = "postgres-rw.${module.k8s_local.postgres_namespace}.svc.cluster.local"
 
   local_db_username = "postgres"
+
+  # SeaweedFS S3 endpoint without the scheme. Loki/Tempo S3 clients take a
+  # host:port endpoint plus an explicit insecure (http) flag, whereas the
+  # GoodData.CN chart consumes the full URL form.
+  local_obs_s3_endpoint_host = replace(module.k8s_local.seaweedfs_s3_endpoint, "http://", "")
 }
 
 resource "random_password" "local_postgres_password" {
@@ -115,6 +120,45 @@ module "k8s_common" {
   loki_retention_period       = var.loki_retention_period
   prometheus_retention_period = var.prometheus_retention_period
   tempo_retention_period      = var.tempo_retention_period
+
+  # Observability object storage: Loki + Tempo write to the local SeaweedFS S3
+  # buckets instead of large PVCs. SeaweedFS has no workload identity, so static
+  # S3 credentials are passed; path-style + insecure (http) for the in-cluster
+  # endpoint. (obs_sa_annotations / obs_pod_labels stay empty — no IRSA/WI.)
+  loki_objstore = {
+    object_store = "s3"
+    storage = {
+      type = "s3"
+      # The SingleBinary chart references all three bucket names even with
+      # ruler/admin features off; point them at the one loki bucket.
+      bucketNames = {
+        chunks = module.k8s_local.seaweedfs_bucket_loki
+        ruler  = module.k8s_local.seaweedfs_bucket_loki
+        admin  = module.k8s_local.seaweedfs_bucket_loki
+      }
+      s3 = {
+        endpoint         = local.local_obs_s3_endpoint_host
+        region           = module.k8s_local.seaweedfs_region
+        accessKeyId      = module.k8s_local.seaweedfs_gdcn_access_key
+        secretAccessKey  = module.k8s_local.seaweedfs_gdcn_secret_key
+        s3ForcePathStyle = true
+        insecure         = true
+      }
+    }
+  }
+  tempo_objstore = {
+    backend = "s3"
+    s3 = {
+      bucket         = module.k8s_local.seaweedfs_bucket_tempo
+      endpoint       = local.local_obs_s3_endpoint_host
+      region         = module.k8s_local.seaweedfs_region
+      access_key     = module.k8s_local.seaweedfs_gdcn_access_key
+      secret_key     = module.k8s_local.seaweedfs_gdcn_secret_key
+      forcepathstyle = true
+      insecure       = true
+    }
+    wal = { path = "/var/tempo/wal" }
+  }
 
   gdcn_helm_extra_values = var.gdcn_helm_extra_values
 

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -86,8 +86,8 @@ gdcn_orgs = [
 # enable_observability = true
 # observability_hostname = "observability.localhost"
 
-# Uncomment to override data retention (defaults shown). Each signal has its own 5Gi
-# PVC, so lower these to bound storage. Loki must be a multiple of 24h.
+# Uncomment to override data retention (defaults shown). Loki/Tempo store data
+# in SeaweedFS S3, so retention bounds bucket usage. Loki needs a multiple of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
 # tempo_retention_period      = "168h"

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -87,10 +87,17 @@ gdcn_orgs = [
 # observability_hostname = "observability.localhost"
 
 # Uncomment to override data retention (defaults shown). Loki/Tempo store data
-# in SeaweedFS S3, so retention bounds bucket usage. Loki needs a multiple of 24h.
+# in SeaweedFS S3, so retention bounds their bucket usage. Loki needs a multiple
+# of 24h.
 # loki_retention_period       = "168h"
 # prometheus_retention_period = "168h"
 # tempo_retention_period      = "168h"
+
+# One SeaweedFS PVC backs every local bucket — Quiver cache, exports, datasource
+# FS and the Loki/Tempo buckets — so size it for all of them, not just for
+# observability retention. Cannot be resized in place; raising it later means
+# deleting and recreating the PVC.
+# seaweedfs_storage_size = "50Gi"
 
 ###
 # Container registry authentication (optional)

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -95,7 +95,8 @@ gdcn_orgs = [
 
 # One SeaweedFS PVC backs every local bucket — Quiver cache, exports, datasource
 # FS and the Loki/Tempo buckets — so size it for all of them, not just for
-# observability retention. Cannot be resized in place; raising it later means
+# observability retention. Under local-path this is not enforced as a quota, so
+# watch the node's free disk. Cannot be resized in place; raising it later means
 # deleting and recreating the PVC.
 # seaweedfs_storage_size = "50Gi"
 

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -294,6 +294,12 @@ variable "registry_quayio" {
   default     = "quay.io"
 }
 
+variable "seaweedfs_storage_size" {
+  description = "Size of the SeaweedFS data PVC backing every local S3 bucket (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces). local-path cannot expand a PVC in place, so raising this on an existing deployment means deleting and recreating the PVC."
+  type        = string
+  default     = "50Gi"
+}
+
 variable "size_profile" {
   description = "Sizing profile for GoodData.CN and supporting services. Local installs only support \"dev\"."
   type        = string

--- a/local/variables.tf
+++ b/local/variables.tf
@@ -295,7 +295,7 @@ variable "registry_quayio" {
 }
 
 variable "seaweedfs_storage_size" {
-  description = "Size of the SeaweedFS data PVC backing every local S3 bucket (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces). local-path cannot expand a PVC in place, so raising this on an existing deployment means deleting and recreating the PVC."
+  description = "Size of the SeaweedFS data PVC backing every local S3 bucket (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces). Under local-path this request is not enforced as a quota — the node's disk is the real limit — and the PVC cannot be expanded in place, so raising this on an existing deployment means deleting and recreating it."
   type        = string
   default     = "50Gi"
 }

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -133,10 +133,8 @@ resource "helm_release" "loki" {
             }
           }]
         }
-        # Retention is enforced by the compactor loop below. retention_period
-        # caps log age; the PVC (size set per tier in size-profiles.tf) still
-        # caps total size, so at high log volume data may be evicted before this
-        # period is reached.
+        # Retention is enforced by the compactor loop below; retention_period
+        # caps log age and bounds object-storage usage.
         limits_config = {
           retention_period = var.loki_retention_period
         }

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -12,6 +12,9 @@ resource "kubernetes_namespace_v1" "observability" {
 locals {
   # Observability sizing (obs_mem / obs_disk) lives in size-profiles.tf.
 
+  # Loki's backend name: the configured object store, else local filesystem.
+  loki_object_store = var.loki_objstore != null ? var.loki_objstore.object_store : "filesystem"
+
   # dotdc Kubernetes dashboards loaded into Grafana (see dashboards block below).
   grafana_kubernetes_dashboards = [
     "k8s-system-api-server",
@@ -125,7 +128,7 @@ resource "helm_release" "loki" {
           configs = [{
             from         = "2024-01-01"
             store        = "tsdb"
-            object_store = var.loki_objstore != null ? var.loki_objstore.object_store : "filesystem"
+            object_store = local.loki_object_store
             schema       = "v13"
             index = {
               prefix = "index_"
@@ -140,7 +143,7 @@ resource "helm_release" "loki" {
         }
         compactor = {
           retention_enabled    = true
-          delete_request_store = var.loki_objstore != null ? var.loki_objstore.object_store : "filesystem"
+          delete_request_store = local.loki_object_store
         }
         auth_enabled = false
       }

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -79,11 +79,10 @@ resource "helm_release" "kube_prometheus_stack" {
           }
           storageSpec = {
             volumeClaimTemplate = {
-              spec = {
-                resources = {
-                  requests = { storage = local.obs_disk.prometheus }
-                }
-              }
+              spec = merge(
+                { resources = { requests = { storage = local.obs_disk.prometheus } } },
+                var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+              )
             }
           }
           # Discover all PodMonitors/ServiceMonitors cluster-wide, not just
@@ -117,14 +116,16 @@ resource "helm_release" "loki" {
         commonConfig = {
           replication_factor = 1
         }
-        storage = {
-          type = "filesystem"
-        }
+        # Object storage (Azure Blob / S3 / SeaweedFS) when loki_objstore is
+        # set; else local filesystem. Retention then lives in the bucket. try()
+        # (not a ternary) sidesteps inconsistent-conditional-type errors, since
+        # the objstore block and the filesystem fallback have different shapes.
+        storage = try(var.loki_objstore.storage, { type = "filesystem" })
         schemaConfig = {
           configs = [{
             from         = "2024-01-01"
             store        = "tsdb"
-            object_store = "filesystem"
+            object_store = var.loki_objstore != null ? var.loki_objstore.object_store : "filesystem"
             schema       = "v13"
             index = {
               prefix = "index_"
@@ -141,16 +142,24 @@ resource "helm_release" "loki" {
         }
         compactor = {
           retention_enabled    = true
-          delete_request_store = "filesystem"
+          delete_request_store = var.loki_objstore != null ? var.loki_objstore.object_store : "filesystem"
         }
         auth_enabled = false
       }
+      # Object-storage auth (workload identity / IRSA) rides on this SA.
+      serviceAccount = {
+        name        = "loki"
+        annotations = var.obs_sa_annotations
+      }
       singleBinary = {
-        replicas = 1
-        persistence = {
-          enabled = true
-          size    = local.obs_disk.loki
-        }
+        replicas  = 1
+        podLabels = var.obs_pod_labels
+        # On object storage this PVC holds only the WAL + index cache, so it is
+        # a small fixed size (obs_wal_disk), not retention-sized.
+        persistence = merge(
+          { enabled = true, size = var.obs_wal_disk },
+          var.gdcn_storage_class != "" ? { storageClass = var.gdcn_storage_class } : {}
+        )
         resources = {
           requests = {
             cpu    = "100m"
@@ -236,7 +245,7 @@ resource "helm_release" "tempo" {
 
   values = [
     yamlencode({
-      tempo = {
+      tempo = merge({
         image = { registry = var.registry_dockerio }
         receivers = {
           jaeger = {
@@ -269,11 +278,26 @@ resource "helm_release" "tempo" {
             }
           }
         }
+        }, var.tempo_objstore != null ? {
+        # Object-storage trace backend (Azure Blob / S3 / SeaweedFS).
+        storage = { trace = var.tempo_objstore }
+      } : {})
+      # NOTE: this chart reads pod labels from TOP-LEVEL podLabels, not
+      # tempo.podLabels. The label triggers the Azure workload-identity webhook
+      # to inject AZURE_CLIENT_ID (paired with the SA annotation below); without
+      # it Tempo's Blob client fails with "no client ID specified".
+      podLabels = var.obs_pod_labels
+      # Object-storage auth (workload identity / IRSA) rides on this SA.
+      serviceAccount = {
+        name        = "tempo"
+        annotations = var.obs_sa_annotations
       }
-      persistence = {
-        enabled = true
-        size    = local.obs_disk.tempo
-      }
+      # On object storage this PVC holds only the WAL, so it is a small fixed
+      # size (obs_wal_disk), not retention-sized.
+      persistence = merge(
+        { enabled = true, size = var.obs_wal_disk },
+        var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+      )
       resources = {
         requests = {
           cpu    = "50m"
@@ -311,10 +335,10 @@ resource "helm_release" "grafana" {
       deploymentStrategy = {
         type = "Recreate"
       }
-      persistence = {
-        enabled = true
-        size    = "1Gi"
-      }
+      persistence = merge(
+        { enabled = true, size = "1Gi" },
+        var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+      )
       resources = {
         requests = {
           cpu    = "50m"
@@ -471,7 +495,9 @@ resource "helm_release" "grafana" {
   wait_for_jobs = true
   timeout       = 1800
 
-  depends_on = [helm_release.kube_prometheus_stack, helm_release.loki, helm_release.tempo]
+  # ingress_nginx included so Grafana's Ingress isn't created until the admission
+  # webhook controller is up (it creates an Ingress; see ingress block above).
+  depends_on = [helm_release.kube_prometheus_stack, helm_release.loki, helm_release.tempo, helm_release.ingress_nginx]
 }
 
 resource "kubectl_manifest" "peerauth_observability_strict" {

--- a/modules/k8s-common/size-profiles.tf
+++ b/modules/k8s-common/size-profiles.tf
@@ -1,10 +1,11 @@
 ###
-# Cloud-agnostic workload sizing for the shared module. These values are the
-# same across AWS/Azure/local at a given tier, so they live here once and each
-# environment's size-profiles.tf selects a tier by name (var.observability_size,
-# var.gdcn_size, var.pulsar_size, var.starrocks_size_profile). GoodData.CN /
-# Pulsar / StarRocks sizing is in templates/*-size-<tier>.yaml.tftpl; the
-# observability stack (no per-tier Helm chart) is sized here.
+# Cloud-agnostic observability sizing for the shared module. These values are
+# the same across AWS/Azure/local at a given tier, so they live here once and
+# the environment selects a tier by name via var.observability_size. Only the
+# observability stack (no per-tier Helm chart) is sized here; GoodData.CN,
+# Pulsar, and StarRocks sizing is selected by var.gdcn_size / var.pulsar_size /
+# var.starrocks_size_profile against templates/*-size-<tier>.yaml.tftpl and
+# starrocks.tf, not this file.
 #
 # Observability CPU is intentionally left flat per-service (these components are
 # memory-bound, not CPU-bound, at our scale). The disk values are StatefulSet
@@ -25,9 +26,9 @@ locals {
           promtail   = { request = "64Mi", limit = "256Mi" }
         }
         disk = {
+          # Loki/Tempo are object-storage backed (only a small WAL PVC remains,
+          # see obs_wal_disk); Prometheus stays PVC-backed.
           prometheus = "5Gi"
-          loki       = "5Gi"
-          tempo      = "5Gi"
         }
         # Per-tenant Tempo trace-ingestion limits. dev uses Tempo's defaults.
         tempo_ingestion = {
@@ -46,9 +47,9 @@ locals {
           promtail   = { request = "128Mi", limit = "256Mi" }
         }
         disk = {
+          # Loki/Tempo are object-storage backed (only a small WAL PVC remains,
+          # see obs_wal_disk); Prometheus stays PVC-backed.
           prometheus = "10Gi"
-          loki       = "10Gi"
-          tempo      = "10Gi"
         }
         # Raised above Tempo defaults to stop RATE_LIMITED drops at peak.
         tempo_ingestion = {
@@ -70,9 +71,10 @@ locals {
           promtail = { request = "128Mi", limit = "512Mi" }
         }
         disk = {
-          prometheus = "20Gi"
-          loki       = "20Gi"
-          tempo      = "20Gi"
+          # Loki/Tempo are object-storage backed (retention lives in the bucket;
+          # only a small fixed WAL PVC remains, see obs_wal_disk). Prometheus
+          # stays PVC-backed (no native object-store mode without Thanos/Mimir).
+          prometheus = "100Gi"
         }
         tempo_ingestion = {
           rate_limit_bytes = 50000000 # 50 MB/s
@@ -82,8 +84,12 @@ locals {
     }
   }
 
-  profile             = local.size_profiles[var.observability_size]
-  obs_mem             = local.profile.observability.memory
-  obs_disk            = local.profile.observability.disk
-  obs_tempo_ingestion = local.profile.observability.tempo_ingestion
+  # Valid workload size tiers = the keys of the size_profiles map above; used by
+  # the gdcn_size / observability_size / pulsar_size variable validations.
+  workload_size_tiers = keys(local.size_profiles)
+
+  obs_profile         = local.size_profiles[var.observability_size]
+  obs_mem             = local.obs_profile.observability.memory
+  obs_disk            = local.obs_profile.observability.disk
+  obs_tempo_ingestion = local.obs_profile.observability.tempo_ingestion
 }

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -377,7 +377,7 @@ variable "obs_pod_labels" {
 }
 
 variable "obs_wal_disk" {
-  description = "Fixed WAL/scratch PVC size for Loki/Tempo when backed by object storage (no longer retention-sized)."
+  description = "Fixed WAL/scratch PVC size for Loki/Tempo when backed by object storage."
   type        = string
   default     = "10Gi"
 }

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -263,7 +263,7 @@ variable "gdcn_size" {
   type = string
   validation {
     condition     = contains(local.workload_size_tiers, var.gdcn_size)
-    error_message = "gdcn_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
+    error_message = "gdcn_size must be one of: ${join(", ", local.workload_size_tiers)} (fold prod-xl to prod-large in the env's size-profiles.tf)."
   }
 }
 
@@ -277,7 +277,7 @@ variable "observability_size" {
   type = string
   validation {
     condition     = contains(local.workload_size_tiers, var.observability_size)
-    error_message = "observability_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
+    error_message = "observability_size must be one of: ${join(", ", local.workload_size_tiers)} (fold prod-xl to prod-large in the env's size-profiles.tf)."
   }
 }
 
@@ -285,7 +285,7 @@ variable "pulsar_size" {
   type = string
   validation {
     condition     = contains(local.workload_size_tiers, var.pulsar_size)
-    error_message = "pulsar_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
+    error_message = "pulsar_size must be one of: ${join(", ", local.workload_size_tiers)} (fold prod-xl to prod-large in the env's size-profiles.tf)."
   }
 }
 

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -259,7 +259,13 @@ variable "starrocks_s3_bucket_id" {
 variable "ingress_replicas" { type = number }
 
 # Workload size selectors, resolved by each env's size-profiles.tf.
-variable "gdcn_size" { type = string }
+variable "gdcn_size" {
+  type = string
+  validation {
+    condition     = contains(local.workload_size_tiers, var.gdcn_size)
+    error_message = "gdcn_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
+  }
+}
 
 variable "gdcn_storage_class" {
   description = "Kubernetes StorageClass for GoodData.CN chart PVCs (etcd, redis-ha, qdrant). Empty string leaves them on the cluster default class."
@@ -267,9 +273,21 @@ variable "gdcn_storage_class" {
   default     = ""
 }
 
-variable "observability_size" { type = string }
+variable "observability_size" {
+  type = string
+  validation {
+    condition     = contains(local.workload_size_tiers, var.observability_size)
+    error_message = "observability_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
+  }
+}
 
-variable "pulsar_size" { type = string }
+variable "pulsar_size" {
+  type = string
+  validation {
+    condition     = contains(local.workload_size_tiers, var.pulsar_size)
+    error_message = "pulsar_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
+  }
+}
 
 # Required only when enable_ai_lake is true (StarRocks is AWS-only); null otherwise.
 variable "starrocks_size_profile" {
@@ -326,4 +344,40 @@ variable "gdcn_helm_extra_values" {
   description = "Additional Helm values YAML string appended to the gooddata-cn chart values. Use to override sub-chart settings not exposed as Terraform variables."
   type        = string
   default     = ""
+}
+
+# --- Observability object storage (Loki/Tempo) -----------------------------
+# When set, Loki/Tempo store chunks/index/trace-blocks in object storage
+# (Azure Blob / S3 / SeaweedFS) instead of a large local PVC. Retention then
+# lives in the bucket; the pods keep only a small fixed WAL PVC (obs_wal_disk).
+# Built per-cloud and passed in; null => legacy filesystem behaviour.
+
+variable "loki_objstore" {
+  description = "Loki object-storage config: { object_store = \"azure\"|\"s3\", storage = <loki.storage block> }. Null => filesystem."
+  type        = any
+  default     = null
+}
+
+variable "tempo_objstore" {
+  description = "Tempo trace object-storage config (the storage.trace block: backend + backend-specific block). Null => filesystem."
+  type        = any
+  default     = null
+}
+
+variable "obs_sa_annotations" {
+  description = "ServiceAccount annotations applied to Loki/Tempo for object-storage auth (Azure workload-identity client-id / AWS IRSA role-arn)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "obs_pod_labels" {
+  description = "Pod labels applied to Loki/Tempo (e.g. azure.workload.identity/use=true to trigger the workload-identity webhook)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "obs_wal_disk" {
+  description = "Fixed WAL/scratch PVC size for Loki/Tempo when backed by object storage (no longer retention-sized)."
+  type        = string
+  default     = "10Gi"
 }

--- a/modules/k8s-local/outputs.tf
+++ b/modules/k8s-local/outputs.tf
@@ -34,6 +34,17 @@ output "seaweedfs_gdcn_secret_key" {
   sensitive   = true
 }
 
+output "seaweedfs_loki_access_key" {
+  description = "Access key for the Loki SeaweedFS S3 user (scoped to the Loki bucket)."
+  value       = "loki"
+}
+
+output "seaweedfs_loki_secret_key" {
+  description = "Secret key for the Loki SeaweedFS S3 user."
+  value       = random_password.seaweedfs_scoped_secret_key["loki"].result
+  sensitive   = true
+}
+
 output "seaweedfs_namespace" {
   description = "Namespace used for SeaweedFS resources."
   value       = kubernetes_namespace_v1.seaweedfs.metadata[0].name
@@ -52,6 +63,17 @@ output "seaweedfs_s3_endpoint" {
     kubernetes_namespace_v1.seaweedfs.metadata[0].name,
     "8333",
   )
+}
+
+output "seaweedfs_tempo_access_key" {
+  description = "Access key for the Tempo SeaweedFS S3 user (scoped to the Tempo bucket)."
+  value       = "tempo"
+}
+
+output "seaweedfs_tempo_secret_key" {
+  description = "Secret key for the Tempo SeaweedFS S3 user."
+  value       = random_password.seaweedfs_scoped_secret_key["tempo"].result
+  sensitive   = true
 }
 
 output "postgres_namespace" {

--- a/modules/k8s-local/outputs.tf
+++ b/modules/k8s-local/outputs.tf
@@ -8,9 +8,19 @@ output "seaweedfs_bucket_exports" {
   value       = var.seaweedfs_bucket_exports
 }
 
+output "seaweedfs_bucket_loki" {
+  description = "SeaweedFS bucket for Loki object storage (chunks/index)."
+  value       = var.seaweedfs_bucket_loki
+}
+
 output "seaweedfs_bucket_quiver_cache" {
   description = "SeaweedFS bucket for Quiver durable cache."
   value       = var.seaweedfs_bucket_quiver_cache
+}
+
+output "seaweedfs_bucket_tempo" {
+  description = "SeaweedFS bucket for Tempo trace object storage."
+  value       = var.seaweedfs_bucket_tempo
 }
 
 output "seaweedfs_gdcn_access_key" {

--- a/modules/k8s-local/seaweedfs.tf
+++ b/modules/k8s-local/seaweedfs.tf
@@ -137,9 +137,9 @@ resource "helm_release" "seaweedfs" {
         }
 
         # Single PVC backs every bucket (Quiver cache, exports, datasource FS,
-        # Loki chunks, Tempo traces), so it must be sized for all of them.
-        # local-path is thin-provisioned: the request is a ceiling, not a
-        # preallocation.
+        # Loki chunks, Tempo traces), so it must be sized for all of them. Under
+        # local-path the request is neither preallocated nor enforced as a
+        # quota, so the real limit is the node's disk — size and watch that.
         data = {
           type         = "persistentVolumeClaim"
           size         = var.seaweedfs_storage_size

--- a/modules/k8s-local/seaweedfs.tf
+++ b/modules/k8s-local/seaweedfs.tf
@@ -15,6 +15,36 @@ locals {
     var.seaweedfs_bucket_loki,
     var.seaweedfs_bucket_tempo,
   ]
+
+  # Observability S3 users, each confined to its own bucket. Keeps a compromised
+  # Loki/Tempo pod away from exports, datasource files and the Quiver cache.
+  seaweedfs_scoped_users = {
+    loki  = var.seaweedfs_bucket_loki
+    tempo = var.seaweedfs_bucket_tempo
+  }
+
+  # Identity/permission config handed to the S3 gateway via -s3.config. gdcn
+  # keeps the account-wide actions the chart's own secret would have granted.
+  seaweedfs_s3_config = {
+    identities = concat(
+      [{
+        name = local.seaweedfs_s3_access_key
+        credentials = [{
+          accessKey = local.seaweedfs_s3_access_key
+          secretKey = kubernetes_secret_v1.seaweedfs_s3_credentials.data["secretKey"]
+        }]
+        actions = ["Admin", "Read", "Write"]
+      }],
+      [for user, bucket in local.seaweedfs_scoped_users : {
+        name = user
+        credentials = [{
+          accessKey = user
+          secretKey = random_password.seaweedfs_scoped_secret_key[user].result
+        }]
+        actions = [for action in ["Read", "Write", "List", "Tagging"] : "${action}:${bucket}"]
+      }]
+    )
+  }
 }
 
 resource "kubernetes_namespace_v1" "seaweedfs" {
@@ -45,6 +75,25 @@ resource "kubernetes_secret_v1" "seaweedfs_s3_credentials" {
   lifecycle {
     # After first apply, don't rotate credentials unless explicitly tainted/replaced.
     ignore_changes = [data]
+  }
+}
+
+resource "random_password" "seaweedfs_scoped_secret_key" {
+  for_each = local.seaweedfs_scoped_users
+
+  length  = 40
+  special = false
+}
+
+resource "kubernetes_secret_v1" "seaweedfs_s3_config" {
+  metadata {
+    name      = "seaweedfs-s3-config"
+    namespace = kubernetes_namespace_v1.seaweedfs.metadata[0].name
+  }
+
+  type = "Opaque"
+  data = {
+    seaweedfs_s3_config = jsonencode(local.seaweedfs_s3_config)
   }
 }
 
@@ -88,9 +137,9 @@ resource "helm_release" "seaweedfs" {
         }
 
         # Single PVC backs every bucket (Quiver cache, exports, datasource FS,
-        # and now Loki/Tempo object storage), so it must be sized for all of
-        # them. local-path is thin-provisioned, so the request is a ceiling, not
-        # a preallocation.
+        # Loki chunks, Tempo traces), so it must be sized for all of them.
+        # local-path is thin-provisioned: the request is a ceiling, not a
+        # preallocation.
         data = {
           type         = "persistentVolumeClaim"
           size         = var.seaweedfs_storage_size
@@ -114,23 +163,18 @@ resource "helm_release" "seaweedfs" {
       volume = { enabled = false }
       filer  = { enabled = false }
 
-      # Credentials are read from the top-level s3 block regardless of mode.
-      # enableAuth must be set here (not only in allInOne.s3) so the chart's
-      # s3-secret template creates the seaweedfs-s3-secret Secret.
+      # The S3 gateway config is read from the top-level s3 block regardless of
+      # mode. existingConfigSecret supplies our own identities (the chart's
+      # generated secret only knows an account-wide admin and a read-only user).
       s3 = {
-        enableAuth = true
-        credentials = {
-          admin = {
-            accessKey = local.seaweedfs_s3_access_key
-            secretKey = kubernetes_secret_v1.seaweedfs_s3_credentials.data["secretKey"]
-          }
-        }
+        enableAuth           = true
+        existingConfigSecret = kubernetes_secret_v1.seaweedfs_s3_config.metadata[0].name
       }
     })
   ]
 
   depends_on = [
-    kubernetes_secret_v1.seaweedfs_s3_credentials,
+    kubernetes_secret_v1.seaweedfs_s3_config,
   ]
 }
 

--- a/modules/k8s-local/seaweedfs.tf
+++ b/modules/k8s-local/seaweedfs.tf
@@ -11,6 +11,9 @@ locals {
     var.seaweedfs_bucket_exports,
     var.seaweedfs_bucket_datasource_fs,
     var.seaweedfs_bucket_quiver_cache,
+    # Observability object storage (Loki chunks/index, Tempo trace blocks).
+    var.seaweedfs_bucket_loki,
+    var.seaweedfs_bucket_tempo,
   ]
 }
 
@@ -84,9 +87,13 @@ resource "helm_release" "seaweedfs" {
           # output.  Buckets are created by the kubernetes_job below instead.
         }
 
+        # Single PVC backs every bucket (Quiver cache, exports, datasource FS,
+        # and now Loki/Tempo object storage), so it must be sized for all of
+        # them. local-path is thin-provisioned, so the request is a ceiling, not
+        # a preallocation.
         data = {
           type         = "persistentVolumeClaim"
-          size         = "10Gi"
+          size         = var.seaweedfs_storage_size
           storageClass = var.seaweedfs_storage_class
         }
 

--- a/modules/k8s-local/variables.tf
+++ b/modules/k8s-local/variables.tf
@@ -85,30 +85,60 @@ variable "seaweedfs_bucket_datasource_fs" {
   description = "Bucket used for Quiver datasource filesystem (CSV uploads)."
   type        = string
   default     = "gooddata-datasource-fs"
+
+  # Interpolated into the bucket-creation shell script in seaweedfs.tf.
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.seaweedfs_bucket_datasource_fs))
+    error_message = "seaweedfs_bucket_datasource_fs must be a valid S3 bucket name: 3-63 chars, lowercase alphanumeric, dots and hyphens, starting and ending alphanumeric."
+  }
 }
 
 variable "seaweedfs_bucket_exports" {
   description = "Bucket used for exports."
   type        = string
   default     = "gooddata-exports"
+
+  # Interpolated into the bucket-creation shell script in seaweedfs.tf.
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.seaweedfs_bucket_exports))
+    error_message = "seaweedfs_bucket_exports must be a valid S3 bucket name: 3-63 chars, lowercase alphanumeric, dots and hyphens, starting and ending alphanumeric."
+  }
 }
 
 variable "seaweedfs_bucket_loki" {
   description = "Bucket used for Loki object storage (chunks/index)."
   type        = string
   default     = "gooddata-loki"
+
+  # Interpolated into the bucket-creation shell script in seaweedfs.tf.
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.seaweedfs_bucket_loki))
+    error_message = "seaweedfs_bucket_loki must be a valid S3 bucket name: 3-63 chars, lowercase alphanumeric, dots and hyphens, starting and ending alphanumeric."
+  }
 }
 
 variable "seaweedfs_bucket_quiver_cache" {
   description = "Bucket used for Quiver durable cache."
   type        = string
   default     = "gooddata-quiver-cache"
+
+  # Interpolated into the bucket-creation shell script in seaweedfs.tf.
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.seaweedfs_bucket_quiver_cache))
+    error_message = "seaweedfs_bucket_quiver_cache must be a valid S3 bucket name: 3-63 chars, lowercase alphanumeric, dots and hyphens, starting and ending alphanumeric."
+  }
 }
 
 variable "seaweedfs_bucket_tempo" {
   description = "Bucket used for Tempo trace object storage."
   type        = string
   default     = "gooddata-tempo"
+
+  # Interpolated into the bucket-creation shell script in seaweedfs.tf.
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.seaweedfs_bucket_tempo))
+    error_message = "seaweedfs_bucket_tempo must be a valid S3 bucket name: 3-63 chars, lowercase alphanumeric, dots and hyphens, starting and ending alphanumeric."
+  }
 }
 
 variable "seaweedfs_release_name" {
@@ -124,7 +154,7 @@ variable "seaweedfs_storage_class" {
 }
 
 variable "seaweedfs_storage_size" {
-  description = "Size of the SeaweedFS data PVC. Backs all S3 buckets (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces), so it must hold object-storage retention for every signal."
+  description = "Size of the SeaweedFS data PVC. Backs all S3 buckets (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces), so it must hold object-storage retention for every signal. local-path cannot expand a PVC in place, so raising this on an existing deployment means deleting and recreating the SeaweedFS PVC (losing its buckets)."
   type        = string
   default     = "50Gi"
 }

--- a/modules/k8s-local/variables.tf
+++ b/modules/k8s-local/variables.tf
@@ -37,7 +37,7 @@ variable "helm_cnpg_version" {
   description = "Version of the CloudNativePG Helm chart to deploy."
   type        = string
   # renovate: depName=cloudnative-pg registryUrl=https://cloudnative-pg.github.io/charts
-  default = "0.28.3"
+  default = "0.29.0"
 }
 
 variable "helm_seaweedfs_version" {

--- a/modules/k8s-local/variables.tf
+++ b/modules/k8s-local/variables.tf
@@ -154,7 +154,7 @@ variable "seaweedfs_storage_class" {
 }
 
 variable "seaweedfs_storage_size" {
-  description = "Size of the SeaweedFS data PVC. Backs all S3 buckets (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces), so it must hold object-storage retention for every signal. local-path cannot expand a PVC in place, so raising this on an existing deployment means deleting and recreating the SeaweedFS PVC (losing its buckets)."
+  description = "Size of the SeaweedFS data PVC. Backs all S3 buckets (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces), so it must hold object-storage retention for every signal. Under local-path this request is not enforced as a quota — the node's disk is the real limit — and the PVC cannot be expanded in place, so raising this on an existing deployment means deleting and recreating it (losing its buckets)."
   type        = string
   default     = "50Gi"
 }

--- a/modules/k8s-local/variables.tf
+++ b/modules/k8s-local/variables.tf
@@ -37,7 +37,7 @@ variable "helm_cnpg_version" {
   description = "Version of the CloudNativePG Helm chart to deploy."
   type        = string
   # renovate: depName=cloudnative-pg registryUrl=https://cloudnative-pg.github.io/charts
-  default = "0.29.0"
+  default = "0.28.3"
 }
 
 variable "helm_seaweedfs_version" {
@@ -93,10 +93,22 @@ variable "seaweedfs_bucket_exports" {
   default     = "gooddata-exports"
 }
 
+variable "seaweedfs_bucket_loki" {
+  description = "Bucket used for Loki object storage (chunks/index)."
+  type        = string
+  default     = "gooddata-loki"
+}
+
 variable "seaweedfs_bucket_quiver_cache" {
   description = "Bucket used for Quiver durable cache."
   type        = string
   default     = "gooddata-quiver-cache"
+}
+
+variable "seaweedfs_bucket_tempo" {
+  description = "Bucket used for Tempo trace object storage."
+  type        = string
+  default     = "gooddata-tempo"
 }
 
 variable "seaweedfs_release_name" {
@@ -109,4 +121,10 @@ variable "seaweedfs_storage_class" {
   description = "StorageClass name for SeaweedFS PVC. Empty uses cluster default."
   type        = string
   default     = "local-path"
+}
+
+variable "seaweedfs_storage_size" {
+  description = "Size of the SeaweedFS data PVC. Backs all S3 buckets (Quiver cache, exports, datasource FS, Loki chunks, Tempo traces), so it must hold object-storage retention for every signal."
+  type        = string
+  default     = "50Gi"
 }


### PR DESCRIPTION
Loki and Tempo keep chunks, indexes, and trace blocks in object storage instead of retention-sized PVCs: S3 on AWS, Azure Blob on Azure, SeaweedFS S3 locally. Retention is bounded by the bucket, and each pod keeps only a small fixed WAL volume (`obs_wal_disk`). Auth is keyless in the clouds — IRSA on AWS, workload identity on Azure — with static keys only for local SeaweedFS. Prometheus stays PVC-backed (100Gi at prod-large).

Also here:
- Observability PVCs use `gdcn_storage_class` when set.
- `gdcn_size` / `observability_size` / `pulsar_size` are validated against the known tiers.

Applying recreates the Loki and Tempo StatefulSets.

Stacked on #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added object storage for Loki logs and Tempo traces across AWS, Azure, and local deployments.
  * Added provider-specific authentication, storage configuration, and dedicated observability buckets.
  * Added configurable observability storage sizing, retention settings, storage classes, and SeaweedFS capacity.
  * Added scoped credentials for local observability storage.

* **Documentation**
  * Updated configuration examples to clarify object-storage retention behavior and Loki’s 24-hour retention requirement.

* **Validation**
  * Added validation for supported deployment size profiles and storage bucket names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->