### PR TITLE
feat(size-profiles): prod-large Quiver tuning for recent images

### DIFF
--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -188,7 +188,7 @@ resource "helm_release" "gooddata_cn" {
       s3_datasource_fs_bucket = var.local_s3_datasource_fs_bucket
       s3_quiver_cache_bucket  = var.local_s3_quiver_cache_bucket
     }) : null,
-    templatefile("${path.module}/templates/gdcn-size-${local.size_profile_template}.yaml.tftpl", {}),
+    templatefile("${path.module}/templates/gdcn-size-${local.size_profile_template}.yaml.tftpl", { cloud = var.cloud }),
     var.gdcn_helm_extra_values != "" ? var.gdcn_helm_extra_values : null,
   ])
 

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -27,6 +27,9 @@ deployDedicatedPolicyNodes: true
 # Deploy dedicated Quiver datasource-filesystem nodes to offload datasource reads.
 deployQuiverDatasourceFs: true
 
+# Long-poll AFM execution results instead of client polling.
+enableAfmLongPoll: true
+
 afmExecApi:
   # Netty/WebFlux: blocking calls use Dispatchers.IO (64-thread default caps
   # ~50 req/pod). io.parallelism + ActiveProcessorCount raise per-pod concurrency.
@@ -234,9 +237,16 @@ qdrant:
       memory: 3500Mi
 quiver:
   limitFlightCount: 150000
+  cacheCountLimit: 150000
   concurrentPutRequests: 64
+  # Durable-write concurrency is per-backend: ABS on Azure, S3 on AWS and local (SeaweedFS).
+%{ if cloud == "azure" ~}
+  absDurableStorage:
+    durableABSWritesInProgress: 128
+%{ else ~}
   s3DurableStorage:
     durableS3WritesInProgress: 128
+%{ endif ~}
   storage:
     # Holds the flight catalog (SQLite); must scale with limitFlightCount.
     serverWorkDirSize: 1024Mi
@@ -246,10 +256,10 @@ quiver:
   replicaCount:
     # cache serves every DoGet + absorbs DoPut/S3 writes on cache miss; 2 pods
     # saturated the put pipeline under load.
-    cache: 12
+    cache: 8
     # xtab is I/O-bound (Flight reads from cache); scaled to 18 pods plus widened
     # worker pools (extraEnvVarsXtab) to keep the cross-tab queue clear under load.
-    xtab: 18
+    xtab: 8
   resources:
     cache:
       # Needs real CPU headroom: the single-threaded etcd-view-apply loop needs a
@@ -308,15 +318,23 @@ quiver:
   extraEnvVarsXtab:
     - name: QUIVER_ETCD_NEW_EVENT_READER
       value: "1"
-    # Per-pod xtab throughput is gated by these worker pools, not CPU/replicas:
-    # tasks are I/O-bound (Flight), so widening the pools greatly raises per-pod
-    # throughput at trivial CPU cost.
+    # Cap the dataframe worker pool: xtab spawns TASK_WORKERS subprocesses
+    # sequentially at boot (~2s each, importing polars), so a high count (was 24)
+    # pushed startup past the liveness probe on slower/contended nodes and the pod
+    # self-terminated mid-boot. 8 boots in ~15-20s (under the probe) while keeping
+    # enough concurrency for the I/O-bound cross-tab tasks. POLARS_MAX_THREADS caps
+    # per-worker polars threads to avoid CPU oversubscription.
     - name: QUIVER_DATAFRAME_TASK_THREADS
-      value: "48"
+      value: "12"
     - name: QUIVER_DATAFRAME_TASK_WORKERS
-      value: "24"
+      value: "8"
     - name: QUIVER_DATAFRAME_GATHER_THREADS
-      value: "24"
+      value: "8"
+    - name: POLARS_MAX_THREADS
+      value: "6"
+  # Store the Flight catalog on disk (in the server work dir above).
+  optimizations:
+    etcd_disk_flight_catalog: true
 redis-ha:
   replicas: 3
   # Keep 2/3 sentinel quorum during voluntary disruptions (node drains, Karpenter consolidation)


### PR DESCRIPTION
Tunes the **prod-large** Quiver config for recent Quiver images. All in `gdcn-size-prod-large.yaml.tftpl` (+ one `cloud` template var in `gooddata-cn.tf`):

- `optimizations.etcd_disk_flight_catalog: true` — required by the optimized etcd event loop; xtab crash-loops on startup without it.
- Cap xtab worker pool (`TASK_WORKERS` 24→8, `TASK_THREADS` 48→12, `GATHER` 24→8, `POLARS_MAX_THREADS=6`) + reduce replicas (`cache`/`xtab` 18→8). Workers spawn sequentially at boot, so the old counts pushed startup past the liveness probe → CrashLoopBackOff.
- `enableAfmLongPoll`, `cacheCountLimit: 150000`, and a per-cloud durable-write backend (ABS on Azure / S3 elsewhere).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the large production profile to support long-polling for AFM execution results.
  * Increased Quiver cache capacity and tuned durable storage settings for Azure and non-Azure environments.
  * Adjusted Quiver worker sizing and thread limits for more controlled resource usage.
  * Enabled disk-based Flight catalog storage for improved large-scale configuration handling.
  * Cloud-specific settings are now applied automatically when generating the deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->