### PR TITLE
refactor: share repeated config via locals, harden prod defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Requirements:
 1. Choose your provider and `cd` into its directory: `cd aws`, `cd azure`, or `cd local`
 
 1. Authenticate to your cloud provider's CLI:
-    - For AWS: `aws login` / `aws sso login` (or otherwise configure your AWS credentials)
+    - For AWS: `aws sso login` (or `aws configure`, or otherwise configure your AWS credentials)
     - For Azure: `az login`
     - Azure note: Terraform's Kubernetes authentication uses `kubelogin` with your Azure CLI session.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ Requirements:
 1. Choose your provider and `cd` into its directory: `cd aws`, `cd azure`, or `cd local`
 
 1. Authenticate to your cloud provider's CLI:
-    - For AWS: `aws sso login` (or `aws configure`, or otherwise configure your AWS credentials)
+    - For AWS: `aws sso login` (or `aws configure`, or otherwise configure your AWS credentials).
+      If you set `aws_profile_name` in `settings.tfvars`, authenticate that same
+      profile — `aws sso login --profile <aws_profile_name>` — since Terraform
+      uses it regardless of your default profile.
     - For Azure: `az login`
     - Azure note: Terraform's Kubernetes authentication uses `kubelogin` with your Azure CLI session.
 

--- a/aws/alb-ingress.tf
+++ b/aws/alb-ingress.tf
@@ -241,27 +241,42 @@ resource "null_resource" "alb_cleanup_wait" {
       aws_region="${self.triggers.aws_region}"
       aws_profile="${self.triggers.aws_profile}"
 
+      expected_account="${self.triggers.aws_account_id}"
+
       # The recorded profile is deliberately not replacement-sensitive, so it can
       # be stale by destroy time (renamed or removed). Prefer it, fall back to
-      # whatever credentials the environment provides, rather than stranding the
-      # ALB and with it the VPC.
-      if aws sts get-caller-identity --profile "$aws_profile" >/dev/null 2>&1; then
-        aws_creds="--profile $aws_profile"
-      elif aws sts get-caller-identity >/dev/null 2>&1; then
-        echo "WARNING: profile '$aws_profile' is unusable; using ambient AWS credentials."
-        aws_creds=""
-      else
-        echo "ERROR: no usable AWS credentials (profile '$aws_profile' and environment both failed)." >&2
-        exit 1
+      # ambient credentials — but only ever accept credentials for the account
+      # this ALB was created in. Against another account describe-load-balancers
+      # returns LoadBalancerNotFound, so we would report the ALB gone while the
+      # real one survives, or delete a same-named ALB over there.
+      account_of() { aws "$@" sts get-caller-identity --query Account --output text 2>/dev/null || true; }
+
+      use_profile=1
+      if [ "$(account_of --profile "$aws_profile")" != "$expected_account" ]; then
+        use_profile=""
+        if [ "$(account_of)" != "$expected_account" ]; then
+          echo "ERROR: no credentials for account $expected_account; profile '$aws_profile' and the environment both fail or resolve elsewhere." >&2
+          exit 1
+        fi
+        echo "WARNING: profile '$aws_profile' unusable or bound to another account; using ambient credentials for $expected_account."
       fi
+
+      # Keeps the profile one argument whatever characters it contains.
+      awsx() {
+        if [ -n "$use_profile" ]; then
+          aws --profile "$aws_profile" "$@"
+        else
+          aws "$@"
+        fi
+      }
 
       # Distinguish "ALB not found" from real API errors (auth, throttling, etc.).
       alb_exists() {
         local output
-        output=$(aws elbv2 describe-load-balancers \
+        output=$(awsx elbv2 describe-load-balancers \
           --names "$lb_name" \
           --region "$aws_region" \
-          $aws_creds 2>&1)
+          2>&1)
         local rc=$?
         if [ $rc -eq 0 ]; then
           return 0
@@ -291,10 +306,9 @@ resource "null_resource" "alb_cleanup_wait" {
 
       # Controller didn't clean up in time — force-delete the ALB.
       echo "WARNING: ALB '$lb_name' still exists after 300s. Force-deleting..."
-      lb_arn=$(aws elbv2 describe-load-balancers \
+      lb_arn=$(awsx elbv2 describe-load-balancers \
         --names "$lb_name" \
         --region "$aws_region" \
-        $aws_creds \
         --query 'LoadBalancers[0].LoadBalancerArn' \
         --output text 2>&1) || {
         echo "ERROR: Failed to fetch ALB ARN for '$lb_name' in region '$aws_region' (profile: '$aws_profile'): $lb_arn"
@@ -306,10 +320,10 @@ resource "null_resource" "alb_cleanup_wait" {
         exit 0
       fi
 
-      delete_output=$(aws elbv2 delete-load-balancer \
+      delete_output=$(awsx elbv2 delete-load-balancer \
         --load-balancer-arn "$lb_arn" \
         --region "$aws_region" \
-        $aws_creds 2>&1) || {
+        2>&1) || {
         if echo "$delete_output" | grep -q "LoadBalancerNotFound"; then
           echo "ALB was already deleted (race condition). Continuing."
         else
@@ -323,10 +337,9 @@ resource "null_resource" "alb_cleanup_wait" {
       eni_count=""
       end_eni=$((SECONDS + 120))
       while [ "$SECONDS" -lt "$end_eni" ]; do
-        eni_output=$(aws ec2 describe-network-interfaces \
+        eni_output=$(awsx ec2 describe-network-interfaces \
           --filters "Name=description,Values=*ELB app/$${lb_name}/*" \
           --region "$aws_region" \
-          $aws_creds \
           --query 'length(NetworkInterfaces)' \
           --output text 2>&1) || {
           echo "WARNING: Failed to query ENIs in region '$aws_region' (profile: '$aws_profile'): $eni_output (will retry)"

--- a/aws/alb-ingress.tf
+++ b/aws/alb-ingress.tf
@@ -241,13 +241,27 @@ resource "null_resource" "alb_cleanup_wait" {
       aws_region="${self.triggers.aws_region}"
       aws_profile="${self.triggers.aws_profile}"
 
+      # The recorded profile is deliberately not replacement-sensitive, so it can
+      # be stale by destroy time (renamed or removed). Prefer it, fall back to
+      # whatever credentials the environment provides, rather than stranding the
+      # ALB and with it the VPC.
+      if aws sts get-caller-identity --profile "$aws_profile" >/dev/null 2>&1; then
+        aws_creds="--profile $aws_profile"
+      elif aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "WARNING: profile '$aws_profile' is unusable; using ambient AWS credentials."
+        aws_creds=""
+      else
+        echo "ERROR: no usable AWS credentials (profile '$aws_profile' and environment both failed)." >&2
+        exit 1
+      fi
+
       # Distinguish "ALB not found" from real API errors (auth, throttling, etc.).
       alb_exists() {
         local output
         output=$(aws elbv2 describe-load-balancers \
           --names "$lb_name" \
           --region "$aws_region" \
-          --profile "$aws_profile" 2>&1)
+          $aws_creds 2>&1)
         local rc=$?
         if [ $rc -eq 0 ]; then
           return 0
@@ -280,7 +294,7 @@ resource "null_resource" "alb_cleanup_wait" {
       lb_arn=$(aws elbv2 describe-load-balancers \
         --names "$lb_name" \
         --region "$aws_region" \
-        --profile "$aws_profile" \
+        $aws_creds \
         --query 'LoadBalancers[0].LoadBalancerArn' \
         --output text 2>&1) || {
         echo "ERROR: Failed to fetch ALB ARN for '$lb_name' in region '$aws_region' (profile: '$aws_profile'): $lb_arn"
@@ -295,7 +309,7 @@ resource "null_resource" "alb_cleanup_wait" {
       delete_output=$(aws elbv2 delete-load-balancer \
         --load-balancer-arn "$lb_arn" \
         --region "$aws_region" \
-        --profile "$aws_profile" 2>&1) || {
+        $aws_creds 2>&1) || {
         if echo "$delete_output" | grep -q "LoadBalancerNotFound"; then
           echo "ALB was already deleted (race condition). Continuing."
         else
@@ -312,7 +326,7 @@ resource "null_resource" "alb_cleanup_wait" {
         eni_output=$(aws ec2 describe-network-interfaces \
           --filters "Name=description,Values=*ELB app/$${lb_name}/*" \
           --region "$aws_region" \
-          --profile "$aws_profile" \
+          $aws_creds \
           --query 'length(NetworkInterfaces)' \
           --output text 2>&1) || {
           echo "WARNING: Failed to query ENIs in region '$aws_region' (profile: '$aws_profile'): $eni_output (will retry)"

--- a/aws/alb-ingress.tf
+++ b/aws/alb-ingress.tf
@@ -224,6 +224,12 @@ resource "null_resource" "alb_cleanup_wait" {
     aws_profile = var.aws_profile_name
   }
 
+  lifecycle {
+    # Any trigger change replaces this resource, which force-deletes the ALB
+    # below. The profile is a local credential detail, so renaming it must not.
+    ignore_changes = [triggers["aws_profile"]]
+  }
+
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
@@ -260,8 +266,8 @@ resource "null_resource" "alb_cleanup_wait" {
 
       # Give the LB controller up to 5 min to delete the ALB.
       echo "Waiting up to 300s for ALB '$lb_name' to be deleted by the AWS Load Balancer Controller..."
-      end=$((SECONDS + 300))
-      while [ "$SECONDS" -lt "$end" ]; do
+      end=$(($(date +%s) + 300))
+      while [ "$(date +%s)" -lt "$end" ]; do
         if ! alb_exists; then
           echo "ALB '$lb_name' deleted by the controller."
           exit 0

--- a/aws/alb-ingress.tf
+++ b/aws/alb-ingress.tf
@@ -222,6 +222,9 @@ resource "null_resource" "alb_cleanup_wait" {
     lb_name     = local.alb_load_balancer_name
     aws_region  = var.aws_region
     aws_profile = var.aws_profile_name
+    # Pins the account this ALB lives in, so destroy-time credentials can be
+    # checked against it rather than trusted for being merely valid.
+    aws_account_id = data.aws_caller_identity.current.account_id
   }
 
   lifecycle {

--- a/aws/ecr-pullthrough.tf
+++ b/aws/ecr-pullthrough.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "current" {}
 
 # If image caching is enabled, construct the registry URL. Otherwise, return the upstream one.
 locals {
-  ecr_registry_base = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com"
+  ecr_registry_base = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com"
 
   upstream_registry_dockerio = "registry-1.docker.io"
   registry_dockerio = var.enable_image_cache ? (

--- a/aws/ecr-pullthrough.tf
+++ b/aws/ecr-pullthrough.tf
@@ -7,28 +7,21 @@ data "aws_caller_identity" "current" {}
 
 # If image caching is enabled, construct the registry URL. Otherwise, return the upstream one.
 locals {
+  ecr_registry_base = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com"
+
   upstream_registry_dockerio = "registry-1.docker.io"
-  registry_dockerio = var.enable_image_cache ? format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.id,
-    aws_ecr_pull_through_cache_rule.dockerio[0].ecr_repository_prefix
+  registry_dockerio = var.enable_image_cache ? (
+    "${local.ecr_registry_base}/${aws_ecr_pull_through_cache_rule.dockerio[0].ecr_repository_prefix}"
   ) : local.upstream_registry_dockerio
 
   upstream_registry_quayio = "quay.io"
-  registry_quayio = var.enable_image_cache ? format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.id,
-    aws_ecr_pull_through_cache_rule.quayio[0].ecr_repository_prefix
+  registry_quayio = var.enable_image_cache ? (
+    "${local.ecr_registry_base}/${aws_ecr_pull_through_cache_rule.quayio[0].ecr_repository_prefix}"
   ) : local.upstream_registry_quayio
 
   upstream_registry_k8sio = "registry.k8s.io"
-  registry_k8sio = var.enable_image_cache ? format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.id,
-    aws_ecr_pull_through_cache_rule.k8sio[0].ecr_repository_prefix
+  registry_k8sio = var.enable_image_cache ? (
+    "${local.ecr_registry_base}/${aws_ecr_pull_through_cache_rule.k8sio[0].ecr_repository_prefix}"
   ) : local.upstream_registry_k8sio
 }
 

--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -30,10 +30,11 @@ locals {
   } : {}
 
   # Managed policies shared by every node role (system managed node group here,
-  # and the Karpenter node role in karpenter.tf): EBS CSI driver + image pull,
-  # plus the pull-through cache policy when image caching is enabled.
+  # and the Karpenter node role in karpenter.tf): image pull, plus the
+  # pull-through cache policy when image caching is enabled. EBS volume calls
+  # are made by the CSI controller, which gets AmazonEBSCSIDriverPolicy through
+  # aws_iam_role.ebs_csi_irsa — nodes do not need it.
   node_iam_role_additional_policies = merge({
-    AmazonEBSCSIDriverPolicy           = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
     AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
   }, local.ecr_pull_through_cache_policy)
 

--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -37,7 +37,7 @@ locals {
     AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
   }, local.ecr_pull_through_cache_policy)
 
-  # Node sizing / StarRocks node types: resolved in size-profiles.tf and applied
+  # Node sizing / AI Lake node types: resolved in size-profiles.tf and applied
   # via Karpenter NodePools (see karpenter.tf), not managed node groups.
 }
 
@@ -67,10 +67,19 @@ module "eks" {
     kube-proxy             = {}
     vpc-cni = {
       before_compute = true
+      # Prefix delegation: each ENI slot carries a /28, not one IP, so pod
+      # density stops tracking instance size. maxPods pinned to match below.
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
     }
     aws-ebs-csi-driver = {
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
+      service_account_role_arn    = aws_iam_role.ebs_csi_irsa.arn
     }
   }
 
@@ -85,10 +94,29 @@ module "eks" {
   # workload capacity just-in-time.
   eks_managed_node_groups = {
     system = {
-      ami_type                   = "BOTTLEROCKET_x86_64"
-      instance_types             = [local.system_node_type]
-      use_custom_launch_template = false
-      disk_size                  = 100
+      ami_type       = "BOTTLEROCKET_x86_64"
+      instance_types = [local.system_node_type]
+
+      # A custom launch template is what puts these nodes in the shared node
+      # security group. Bottlerocket stores containers on /dev/xvdb.
+      block_device_mappings = {
+        xvdb = {
+          device_name = "/dev/xvdb"
+          ebs = {
+            volume_size           = var.eks_node_disk_size
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
+
+      # Without this the kubelet keeps the secondary-IP pod limit, leaving
+      # prefix delegation inert here. EKS merges this with its own TOML.
+      bootstrap_extra_args = <<-EOT
+        [settings.kubernetes]
+        max-pods = ${var.eks_node_max_pods}
+      EOT
 
       # Isolate the system pool: only system pods (which tolerate this taint)
       # run here; all workloads go to Karpenter-provisioned nodes. CoreDNS
@@ -105,9 +133,11 @@ module "eks" {
 
       iam_role_additional_policies = local.node_iam_role_additional_policies
 
-      min_size     = 2
-      max_size     = 3
-      desired_size = 2
+      # Sized per size_profile (size-profiles.tf), matching AKS. One spare slot
+      # above desired so a node can be replaced without losing capacity.
+      min_size     = local.system_node_count
+      max_size     = local.system_node_count + 1
+      desired_size = local.system_node_count
     }
   }
 
@@ -117,7 +147,17 @@ module "eks" {
     "karpenter.sh/discovery" = var.deployment_name
   }
 
-  node_security_group_additional_rules = var.ingress_controller == "istio_gateway" ? {
+  # Pod IPs live on node ENIs, so this group governs all pod-to-pod traffic.
+  node_security_group_additional_rules = merge({
+    node_to_node_all = {
+      description = "Node to node, all ports and protocols"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    }, var.ingress_controller == "istio_gateway" ? {
     istio_xds = {
       description                   = "Istio XDS (istiod) to workloads"
       protocol                      = "tcp"
@@ -134,7 +174,7 @@ module "eks" {
       type                          = "ingress"
       source_cluster_security_group = true
     }
-  } : {}
+  } : {})
 }
 
 # Outputs

--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -29,6 +29,14 @@ locals {
     ECRPullThroughCacheMin = aws_iam_policy.ecr_pull_through_cache_min[0].arn
   } : {}
 
+  # Managed policies shared by every node role (system managed node group here,
+  # and the Karpenter node role in karpenter.tf): EBS CSI driver + image pull,
+  # plus the pull-through cache policy when image caching is enabled.
+  node_iam_role_additional_policies = merge({
+    AmazonEBSCSIDriverPolicy           = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+    AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
+  }, local.ecr_pull_through_cache_policy)
+
   # Node sizing / StarRocks node types: resolved in size-profiles.tf and applied
   # via Karpenter NodePools (see karpenter.tf), not managed node groups.
 }
@@ -95,10 +103,7 @@ module "eks" {
 
       tags = local.common_tags
 
-      iam_role_additional_policies = merge({
-        AmazonEBSCSIDriverPolicy           = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-        AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
-      }, local.ecr_pull_through_cache_policy)
+      iam_role_additional_policies = local.node_iam_role_additional_policies
 
       min_size     = 2
       max_size     = 3

--- a/aws/irsa.tf
+++ b/aws/irsa.tf
@@ -35,6 +35,44 @@ resource "aws_iam_role_policy_attachment" "gdcn_irsa_s3_access" {
 }
 
 ###
+# IAM role for the EBS CSI driver (IRSA)
+###
+
+# Without this the driver falls back to IMDS, which pods cannot reach at the
+# default hop limit of 1.
+data "aws_iam_policy_document" "ebs_csi_irsa_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = local.eks_oidc_condition_key
+      values = [
+        "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi_irsa" {
+  name               = "${var.deployment_name}-ebs-csi-irsa"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_irsa_assume_role.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_irsa" {
+  role       = aws_iam_role.ebs_csi_irsa.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+###
 # IAM role for observability (Loki + Tempo) service accounts (IRSA)
 ###
 

--- a/aws/irsa.tf
+++ b/aws/irsa.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "gdcn_irsa_assume_role" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      variable = local.eks_oidc_condition_key
       values = [
         "system:serviceaccount:${var.gdcn_namespace}:${local.gdcn_service_account_name}"
       ]
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "observability_irsa_assume_role" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      variable = local.eks_oidc_condition_key
       values = [
         "system:serviceaccount:observability:loki",
         "system:serviceaccount:observability:tempo",
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "starrocks_irsa_assume_role" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      variable = local.eks_oidc_condition_key
       values = [
         "system:serviceaccount:starrocks:starrocks"
       ]

--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -52,9 +52,10 @@ module "k8s_common" {
   ingress_replicas       = local.profile.ingress_replicas
   gdcn_size              = local.profile.gdcn_size
   gdcn_storage_class     = local.storage_class
+  fast_storage_class     = local.fast_storage_class
   pulsar_size            = local.profile.pulsar_size
   observability_size     = local.profile.observability_size
-  starrocks_size_profile = var.starrocks_size_profile
+  ai_lake_size_profile   = var.ai_lake_size_profile
   cloud                  = "aws"
   ingress_controller     = var.ingress_controller
   gdcn_irsa_role_arn     = aws_iam_role.gdcn_irsa.arn
@@ -161,5 +162,11 @@ module "k8s_common" {
     aws_iam_role_policy.ai_lake_pod_identity,
     aws_eks_pod_identity_association.ai_lake,
     terraform_data.s3tables_lakeformation_permissions,
+    # Node capacity must outlive the helm releases: deleting the NodePools taints
+    # every Karpenter node, and draining the NodeClaims removes it outright,
+    # either of which leaves pre-delete hooks unschedulable.
+    null_resource.karpenter_nodeclaim_drain,
+    kubectl_manifest.karpenter_node_pool,
+    kubectl_manifest.karpenter_node_pool_starrocks,
   ]
 }

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -19,6 +19,10 @@ module "karpenter" {
   # association binding the kube-system/karpenter service account to the role.
   create_pod_identity_association = true
 
+  # The generated controller policy exceeds the 6144-char managed-policy quota.
+  # Inline role policies allow 10240, which fits.
+  enable_inline_policy = true
+
   # Lets Karpenter-launched nodes use the EBS CSI driver and pull images
   # (incl. via the optional pull-through cache).
   node_iam_role_additional_policies = local.node_iam_role_additional_policies
@@ -42,6 +46,9 @@ resource "helm_release" "karpenter" {
     serviceAccount = {
       name = "karpenter"
     }
+    # The chart's default 2 replicas require hostname anti-affinity to be
+    # satisfiable, so one system node means one replica.
+    replicas = min(local.system_node_count, 2)
     settings = {
       clusterName       = module.eks.cluster_name
       clusterEndpoint   = module.eks.cluster_endpoint
@@ -82,6 +89,22 @@ resource "kubectl_manifest" "karpenter_node_class" {
       tags = merge(local.common_tags, {
         "karpenter.sh/discovery" = var.deployment_name
       })
+      # Bottlerocket's default 20 GiB /dev/xvdb is below the ephemeral-storage
+      # some pods request, leaving them unschedulable on every instance type.
+      blockDeviceMappings = [{
+        deviceName = "/dev/xvdb"
+        ebs = {
+          volumeSize          = "${var.eks_node_disk_size}Gi"
+          volumeType          = "gp3"
+          encrypted           = true
+          deleteOnTermination = true
+        }
+      }]
+      # Karpenter sizes maxPods from secondary-IP limits, leaving prefix
+      # delegation (eks.tf) inert. 110 fits every node these pools build.
+      kubelet = {
+        maxPods = var.eks_node_max_pods
+      }
     }
   })
 
@@ -126,9 +149,11 @@ resource "kubectl_manifest" "karpenter_node_pool" {
       limits = {
         cpu = local.eks_node_cpu_limit
       }
+      # 15m of underutilization before reclaiming a node, so bursty workloads
+      # do not churn capacity.
       disruption = {
         consolidationPolicy = "WhenEmptyOrUnderutilized"
-        consolidateAfter    = "1m"
+        consolidateAfter    = "15m"
       }
     }
   })
@@ -164,7 +189,7 @@ resource "kubectl_manifest" "karpenter_node_pool_starrocks" {
             { key = "kubernetes.io/arch", operator = "In", values = ["amd64"] },
             { key = "kubernetes.io/os", operator = "In", values = ["linux"] },
             { key = "karpenter.sh/capacity-type", operator = "In", values = ["on-demand"] },
-            { key = "node.kubernetes.io/instance-type", operator = "In", values = local.eks_starrocks_node_types },
+            { key = "node.kubernetes.io/instance-type", operator = "In", values = local.eks_ai_lake_node_types },
           ]
           nodeClassRef = {
             group = "karpenter.k8s.aws"
@@ -185,4 +210,120 @@ resource "kubectl_manifest" "karpenter_node_pool_starrocks" {
   })
 
   depends_on = [kubectl_manifest.karpenter_node_class]
+}
+
+# ---------------------------------------------------------------------------
+# Karpenter destroy-time NodeClaim drain
+# ---------------------------------------------------------------------------
+# Only Karpenter can reap its own nodes, by clearing each NodeClaim finalizer.
+# Removing the controller first orphans them: the instances keep billing and
+# their ENIs block subnet, security group and VPC deletion.
+#
+# Destroy order, enforced by depends_on here and in k8s-common.tf:
+#   helm releases  →  nodeclaim_drain  →  node pools  →  node class  →  karpenter
+# ---------------------------------------------------------------------------
+resource "null_resource" "karpenter_nodeclaim_drain" {
+  triggers = {
+    cluster_name = module.eks.cluster_name
+    aws_region   = var.aws_region
+    aws_profile  = var.aws_profile_name
+  }
+
+  lifecycle {
+    # Any trigger change replaces this resource, which runs the drain below. The
+    # profile is a local credential detail, so renaming it must not delete nodes.
+    ignore_changes = [triggers["aws_profile"]]
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      set -eu
+
+      command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI not found"; exit 1; }
+      command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+      cluster_name="${self.triggers.cluster_name}"
+      aws_region="${self.triggers.aws_region}"
+      aws_profile="${self.triggers.aws_profile}"
+
+      kubeconfig=$(mktemp)
+      trap 'rm -f "$kubeconfig"' EXIT
+
+      # Distinguish an already-deleted cluster from a real API error (expired
+      # credentials, wrong profile, no network), which must not skip the drain.
+      if ! err=$(aws eks update-kubeconfig --name "$cluster_name" --region "$aws_region" \
+        --profile "$aws_profile" --kubeconfig "$kubeconfig" 2>&1); then
+        if echo "$err" | grep -q "ResourceNotFoundException"; then
+          echo "Cluster '$cluster_name' no longer exists. Nothing to drain."
+          exit 0
+        fi
+        echo "ERROR: cannot reach cluster '$cluster_name' in '$aws_region' (profile '$aws_profile'): $err" >&2
+        exit 1
+      fi
+
+      kc="kubectl --kubeconfig $kubeconfig"
+
+      # Warn rather than fail: blocking here would make the stack undestroyable.
+      if ! $kc get --raw /readyz >/dev/null 2>&1; then
+        echo "WARNING: cluster '$cluster_name' is unreachable, so NodeClaims cannot be drained."
+        echo "WARNING: check for leftover instances tagged karpenter.sh/nodepool and terminate them,"
+        echo "WARNING: or subnet, security group and VPC deletion will fail."
+        exit 0
+      fi
+
+      if ! $kc get crd nodeclaims.karpenter.sh >/dev/null 2>&1; then
+        echo "NodeClaim CRD not installed. Nothing to drain."
+        exit 0
+      fi
+
+      # Fails instead of printing 0 when the API call itself fails, so a
+      # transient error is never mistaken for an empty cluster.
+      count_claims() {
+        out=$($kc get nodeclaims --no-headers 2>/dev/null) || return 1
+        if [ -z "$out" ]; then echo 0; else echo "$out" | wc -l | tr -d ' '; fi
+      }
+
+      if ! remaining=$(count_claims); then
+        echo "ERROR: cannot list NodeClaims on '$cluster_name'." >&2
+        exit 1
+      fi
+      if [ "$remaining" = "0" ]; then
+        echo "No NodeClaims to drain."
+        exit 0
+      fi
+
+      echo "Deleting $remaining Karpenter NodeClaim(s)..."
+      $kc delete nodeclaims --all --wait=false >/dev/null 2>&1 || true
+
+      # The finalizer clears only after the instance is terminated, so a claim
+      # disappearing means its node is really gone.
+      echo "Waiting up to 900s for Karpenter to terminate them..."
+      i=0
+      while [ "$i" -lt 90 ]; do
+        if remaining=$(count_claims); then
+          if [ "$remaining" = "0" ]; then
+            echo "All NodeClaims drained."
+            exit 0
+          fi
+          echo "Still waiting for $remaining NodeClaim(s)..."
+        else
+          echo "WARNING: could not list NodeClaims, retrying..."
+        fi
+        sleep 10
+        i=$((i + 1))
+      done
+
+      echo "ERROR: NodeClaim(s) still present after 900s."
+      echo "Their instances would be orphaned and their ENIs will block subnet,"
+      echo "security group and VPC deletion. Check the karpenter deployment in"
+      echo "kube-system, then re-run destroy."
+      exit 1
+    EOT
+  }
+
+  depends_on = [
+    kubectl_manifest.karpenter_node_pool,
+    kubectl_manifest.karpenter_node_pool_starrocks,
+  ]
 }

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -247,33 +247,80 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
       aws_region="${self.triggers.aws_region}"
       aws_profile="${self.triggers.aws_profile}"
 
+      # The recorded profile is deliberately not replacement-sensitive, so it can
+      # be stale by destroy time (renamed or removed). Prefer it, fall back to
+      # whatever credentials the environment provides, rather than leaving nodes
+      # running whose ENIs block VPC deletion.
+      if aws sts get-caller-identity --profile "$aws_profile" >/dev/null 2>&1; then
+        aws_creds="--profile $aws_profile"
+      elif aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "WARNING: profile '$aws_profile' is unusable; using ambient AWS credentials."
+        aws_creds=""
+      else
+        echo "ERROR: no usable AWS credentials (profile '$aws_profile' and environment both failed)." >&2
+        exit 1
+      fi
+
+      # Terminate any instance Karpenter still owns. Only needs the EC2 API, so
+      # it is also the fallback when the cluster itself is unreachable.
+      force_terminate_instances() {
+        ids=$(aws ec2 describe-instances --region "$aws_region" $aws_creds \
+          --filters "Name=tag:kubernetes.io/cluster/$cluster_name,Values=owned" \
+                    "Name=tag-key,Values=karpenter.sh/nodeclaim" \
+                    "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+          --query 'Reservations[].Instances[].InstanceId' --output text) || {
+          echo "ERROR: cannot list Karpenter instances to force-terminate." >&2
+          exit 1
+        }
+
+        if [ -z "$ids" ]; then
+          echo "No Karpenter-owned instances remain."
+          return 0
+        fi
+
+        echo "Terminating $ids"
+        aws ec2 terminate-instances --region "$aws_region" $aws_creds \
+          --instance-ids $ids >/dev/null || {
+          echo "ERROR: terminate-instances failed." >&2
+          exit 1
+        }
+        # ENIs only detach once instances reach terminated, and they block
+        # subnet, security group and VPC deletion until they do.
+        echo "Waiting for termination so their ENIs are released..."
+        aws ec2 wait instance-terminated --region "$aws_region" $aws_creds \
+          --instance-ids $ids || echo "WARNING: waiter timed out; VPC deletion may retry."
+      }
+
       kubeconfig=$(mktemp)
       trap 'rm -f "$kubeconfig"' EXIT
 
       # Distinguish an already-deleted cluster from a real API error (expired
       # credentials, wrong profile, no network), which must not skip the drain.
       if ! err=$(aws eks update-kubeconfig --name "$cluster_name" --region "$aws_region" \
-        --profile "$aws_profile" --kubeconfig "$kubeconfig" 2>&1); then
+        $aws_creds --kubeconfig "$kubeconfig" 2>&1); then
         if echo "$err" | grep -q "ResourceNotFoundException"; then
-          echo "Cluster '$cluster_name' no longer exists. Nothing to drain."
+          echo "Cluster '$cluster_name' no longer exists; checking for orphaned instances."
+          force_terminate_instances
           exit 0
         fi
-        echo "ERROR: cannot reach cluster '$cluster_name' in '$aws_region' (profile '$aws_profile'): $err" >&2
+        echo "ERROR: cannot reach cluster '$cluster_name' in '$aws_region': $err" >&2
         exit 1
       fi
 
       kc="kubectl --kubeconfig $kubeconfig"
 
-      # Warn rather than fail: blocking here would make the stack undestroyable.
+      # Unreachable API means Karpenter cannot reap its own nodes, so do it via
+      # EC2 instead. Exiting here would strand instances whose ENIs then block
+      # subnet, security group and VPC deletion.
       if ! $kc get --raw /readyz >/dev/null 2>&1; then
-        echo "WARNING: cluster '$cluster_name' is unreachable, so NodeClaims cannot be drained."
-        echo "WARNING: check for leftover instances tagged karpenter.sh/nodepool and terminate them,"
-        echo "WARNING: or subnet, security group and VPC deletion will fail."
+        echo "WARNING: cluster '$cluster_name' is unreachable; terminating its instances directly."
+        force_terminate_instances
         exit 0
       fi
 
       if ! $kc get crd nodeclaims.karpenter.sh >/dev/null 2>&1; then
-        echo "NodeClaim CRD not installed. Nothing to drain."
+        echo "NodeClaim CRD not installed; checking for orphaned instances."
+        force_terminate_instances
         exit 0
       fi
 
@@ -318,29 +365,8 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
       # so do its job directly: terminate the instances, then clear finalizers.
       echo "WARNING: NodeClaim(s) still present after 900s; forcing cleanup."
 
-      ids=$(aws ec2 describe-instances --region "$aws_region" --profile "$aws_profile" \
-        --filters "Name=tag:kubernetes.io/cluster/$cluster_name,Values=owned" \
-                  "Name=tag-key,Values=karpenter.sh/nodeclaim" \
-                  "Name=instance-state-name,Values=pending,running,stopping,stopped" \
-        --query 'Reservations[].Instances[].InstanceId' --output text) || {
-        echo "ERROR: cannot list Karpenter instances to force-terminate." >&2
-        exit 1
-      }
-
       # Terminate before clearing finalizers, so no instance is left orphaned.
-      if [ -n "$ids" ]; then
-        echo "Terminating $ids"
-        aws ec2 terminate-instances --region "$aws_region" --profile "$aws_profile" \
-          --instance-ids $ids >/dev/null || {
-          echo "ERROR: terminate-instances failed." >&2
-          exit 1
-        }
-        # ENIs only detach once instances reach terminated, and they block
-        # subnet, security group and VPC deletion until they do.
-        echo "Waiting for termination so their ENIs are released..."
-        aws ec2 wait instance-terminated --region "$aws_region" --profile "$aws_profile" \
-          --instance-ids $ids || echo "WARNING: waiter timed out; VPC deletion may retry."
-      fi
+      force_terminate_instances
 
       # Karpenter clears the finalizer only after it observes the instance gone,
       # which it cannot do once it has lost EC2 API reachability.

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -21,10 +21,7 @@ module "karpenter" {
 
   # Lets Karpenter-launched nodes use the EBS CSI driver and pull images
   # (incl. via the optional pull-through cache).
-  node_iam_role_additional_policies = merge({
-    AmazonEBSCSIDriverPolicy           = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-    AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
-  }, local.ecr_pull_through_cache_policy)
+  node_iam_role_additional_policies = local.node_iam_role_additional_policies
 
   tags = local.common_tags
 }
@@ -124,7 +121,8 @@ resource "kubectl_manifest" "karpenter_node_pool" {
           expireAfter = "720h"
         }
       }
-      # Total vCPU ceiling for this NodePool (size-profiles.tf).
+      # Total vCPU ceiling for this NodePool (size-profiles.tf). StarRocks pool
+      # below is uncapped (bounded by fixed replicas).
       limits = {
         cpu = local.eks_node_cpu_limit
       }

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -314,16 +314,50 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
         i=$((i + 1))
       done
 
-      echo "ERROR: NodeClaim(s) still present after 900s."
-      echo "Their instances would be orphaned and their ENIs will block subnet,"
-      echo "security group and VPC deletion. Check the karpenter deployment in"
-      echo "kube-system, then re-run destroy."
-      exit 1
+      # Karpenter is wedged. Failing here would leave the stack undestroyable,
+      # so do its job directly: terminate the instances, then clear finalizers.
+      echo "WARNING: NodeClaim(s) still present after 900s; forcing cleanup."
+
+      ids=$(aws ec2 describe-instances --region "$aws_region" --profile "$aws_profile" \
+        --filters "Name=tag:kubernetes.io/cluster/$cluster_name,Values=owned" \
+                  "Name=tag-key,Values=karpenter.sh/nodeclaim" \
+                  "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+        --query 'Reservations[].Instances[].InstanceId' --output text) || {
+        echo "ERROR: cannot list Karpenter instances to force-terminate." >&2
+        exit 1
+      }
+
+      # Terminate before clearing finalizers, so no instance is left orphaned.
+      if [ -n "$ids" ]; then
+        echo "Terminating $ids"
+        aws ec2 terminate-instances --region "$aws_region" --profile "$aws_profile" \
+          --instance-ids $ids >/dev/null || {
+          echo "ERROR: terminate-instances failed." >&2
+          exit 1
+        }
+        # ENIs only detach once instances reach terminated, and they block
+        # subnet, security group and VPC deletion until they do.
+        echo "Waiting for termination so their ENIs are released..."
+        aws ec2 wait instance-terminated --region "$aws_region" --profile "$aws_profile" \
+          --instance-ids $ids || echo "WARNING: waiter timed out; VPC deletion may retry."
+      fi
+
+      # Karpenter clears the finalizer only after it observes the instance gone,
+      # which it cannot do once it has lost EC2 API reachability.
+      for nc in $($kc get nodeclaims -o name 2>/dev/null); do
+        $kc patch "$nc" --type=merge -p '{"metadata":{"finalizers":null}}' >/dev/null 2>&1 || true
+      done
+
+      echo "Forced cleanup complete."
     EOT
   }
 
+  # Node egress must outlive the drain: kubelets reach the public EKS endpoint
+  # and Karpenter the EC2 API over module.vpc's NAT gateway.
   depends_on = [
     kubectl_manifest.karpenter_node_pool,
     kubectl_manifest.karpenter_node_pool_starrocks,
+    module.vpc,
+    aws_vpc_endpoint.s3,
   ]
 }

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -227,6 +227,9 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
     cluster_name = module.eks.cluster_name
     aws_region   = var.aws_region
     aws_profile  = var.aws_profile_name
+    # Pins the account these nodes live in, so destroy-time credentials can be
+    # checked against it before anything is terminated.
+    aws_account_id = data.aws_caller_identity.current.account_id
   }
 
   lifecycle {
@@ -247,24 +250,38 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
       aws_region="${self.triggers.aws_region}"
       aws_profile="${self.triggers.aws_profile}"
 
+      expected_account="${self.triggers.aws_account_id}"
+
       # The recorded profile is deliberately not replacement-sensitive, so it can
       # be stale by destroy time (renamed or removed). Prefer it, fall back to
-      # whatever credentials the environment provides, rather than leaving nodes
-      # running whose ENIs block VPC deletion.
-      if aws sts get-caller-identity --profile "$aws_profile" >/dev/null 2>&1; then
-        aws_creds="--profile $aws_profile"
-      elif aws sts get-caller-identity >/dev/null 2>&1; then
-        echo "WARNING: profile '$aws_profile' is unusable; using ambient AWS credentials."
-        aws_creds=""
-      else
-        echo "ERROR: no usable AWS credentials (profile '$aws_profile' and environment both failed)." >&2
-        exit 1
+      # ambient credentials — but only ever accept credentials for the account
+      # these nodes live in. This check gates instance termination, so the wrong
+      # account must fail closed rather than act on whatever it can reach.
+      account_of() { aws "$@" sts get-caller-identity --query Account --output text 2>/dev/null || true; }
+
+      use_profile=1
+      if [ "$(account_of --profile "$aws_profile")" != "$expected_account" ]; then
+        use_profile=""
+        if [ "$(account_of)" != "$expected_account" ]; then
+          echo "ERROR: no credentials for account $expected_account; profile '$aws_profile' and the environment both fail or resolve elsewhere." >&2
+          exit 1
+        fi
+        echo "WARNING: profile '$aws_profile' unusable or bound to another account; using ambient credentials for $expected_account."
       fi
+
+      # Keeps the profile one argument whatever characters it contains.
+      awsx() {
+        if [ -n "$use_profile" ]; then
+          aws --profile "$aws_profile" "$@"
+        else
+          aws "$@"
+        fi
+      }
 
       # Terminate any instance Karpenter still owns. Only needs the EC2 API, so
       # it is also the fallback when the cluster itself is unreachable.
       force_terminate_instances() {
-        ids=$(aws ec2 describe-instances --region "$aws_region" $aws_creds \
+        ids=$(awsx ec2 describe-instances --region "$aws_region" \
           --filters "Name=tag:kubernetes.io/cluster/$cluster_name,Values=owned" \
                     "Name=tag-key,Values=karpenter.sh/nodeclaim" \
                     "Name=instance-state-name,Values=pending,running,stopping,stopped" \
@@ -279,7 +296,7 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
         fi
 
         echo "Terminating $ids"
-        aws ec2 terminate-instances --region "$aws_region" $aws_creds \
+        awsx ec2 terminate-instances --region "$aws_region" \
           --instance-ids $ids >/dev/null || {
           echo "ERROR: terminate-instances failed." >&2
           exit 1
@@ -287,7 +304,7 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
         # ENIs only detach once instances reach terminated, and they block
         # subnet, security group and VPC deletion until they do.
         echo "Waiting for termination so their ENIs are released..."
-        aws ec2 wait instance-terminated --region "$aws_region" $aws_creds \
+        awsx ec2 wait instance-terminated --region "$aws_region" \
           --instance-ids $ids || echo "WARNING: waiter timed out; VPC deletion may retry."
       }
 
@@ -296,8 +313,8 @@ resource "null_resource" "karpenter_nodeclaim_drain" {
 
       # Distinguish an already-deleted cluster from a real API error (expired
       # credentials, wrong profile, no network), which must not skip the drain.
-      if ! err=$(aws eks update-kubeconfig --name "$cluster_name" --region "$aws_region" \
-        $aws_creds --kubeconfig "$kubeconfig" 2>&1); then
+      if ! err=$(awsx eks update-kubeconfig --name "$cluster_name" --region "$aws_region" \
+        --kubeconfig "$kubeconfig" 2>&1); then
         if echo "$err" | grep -q "ResourceNotFoundException"; then
           echo "Cluster '$cluster_name' no longer exists; checking for orphaned instances."
           force_terminate_instances

--- a/aws/lakeformation.tf
+++ b/aws/lakeformation.tf
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "s3tables_data_access" {
     ]
 
     resources = [
-      "arn:aws:s3tables:${var.aws_region}:${data.aws_caller_identity.current.account_id}:bucket/*"
+      local.s3tables_bucket_wildcard_arn
     ]
   }
 
@@ -115,11 +115,11 @@ data "aws_iam_policy_document" "s3tables_data_access" {
     ]
 
     resources = [
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog/s3tablescatalog",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog/s3tablescatalog/*",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:database/s3tablescatalog/*",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/s3tablescatalog/*",
+      "${local.glue_arn_prefix}:catalog",
+      "${local.glue_arn_prefix}:catalog/s3tablescatalog",
+      "${local.glue_arn_prefix}:catalog/s3tablescatalog/*",
+      "${local.glue_arn_prefix}:database/s3tablescatalog/*",
+      "${local.glue_arn_prefix}:table/s3tablescatalog/*",
     ]
   }
 }
@@ -147,7 +147,7 @@ resource "aws_iam_role_policy" "s3tables_lakeformation" {
 resource "aws_lakeformation_resource" "s3tables" {
   count = var.enable_ai_lake ? 1 : 0
 
-  arn                    = "arn:aws:s3tables:${var.aws_region}:${data.aws_caller_identity.current.account_id}:bucket/*"
+  arn                    = local.s3tables_bucket_wildcard_arn
   role_arn               = aws_iam_role.s3tables_lakeformation[0].arn
   with_federation        = true
   with_privileged_access = true
@@ -395,13 +395,7 @@ data "aws_iam_policy_document" "s3tables_ailake_access" {
       "glue:GetTable",
       "glue:GetTables",
     ]
-    resources = [
-      "${local.glue_arn_prefix}:catalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}",
-      "${local.glue_arn_prefix}:database/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*",
-      "${local.glue_arn_prefix}:table/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*/*",
-    ]
+    resources = local.glue_s3tables_catalog_arns
   }
 
   statement {
@@ -507,13 +501,7 @@ data "aws_iam_policy_document" "glue_etl_job_access" {
       "glue:UpdateDatabase",
       "glue:GetCatalogImportStatus",
     ]
-    resources = [
-      "${local.glue_arn_prefix}:catalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}",
-      "${local.glue_arn_prefix}:database/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*",
-      "${local.glue_arn_prefix}:table/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*/*",
-    ]
+    resources = local.glue_s3tables_catalog_arns
   }
 
   statement {

--- a/aws/providers.tf
+++ b/aws/providers.tf
@@ -54,6 +54,10 @@ locals {
   # Shared Kubernetes auth settings (aws eks get-token)
   kube_host = module.eks.cluster_endpoint
   kube_ca   = base64decode(module.eks.cluster_certificate_authority_data)
+
+  # OIDC condition key for IRSA trust policies (irsa.tf), e.g.
+  # "oidc.eks.<region>.amazonaws.com/id/<id>:sub"
+  eks_oidc_condition_key = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
   eks_exec = {
     api_version = "client.authentication.k8s.io/v1"
     command     = "aws"

--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -91,8 +91,13 @@ module "rds_postgresql" {
   # Connectivity & lifecycle
   publicly_accessible = false
   storage_encrypted   = true
-  skip_final_snapshot = var.rds_skip_final_snapshot
-  deletion_protection = var.rds_deletion_protection
+  skip_final_snapshot = local.rds_skip_final_snapshot
+  deletion_protection = local.rds_deletion_protection
+
+  # PITR window well past the RDS ~1-day fallback; fixed off-hours windows.
+  backup_retention_period = local.rds_backup_retention_period
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "Sun:04:30-Sun:05:30"
 
   tags = local.common_tags
 }

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -76,8 +76,67 @@ locals {
   gdcn_s3_object_arns = formatlist("%s/*", local.gdcn_s3_bucket_arns)
 
   # Shared ARN fragments for StarRocks Glue/S3 Tables policies
-  glue_arn_prefix     = "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}"
-  s3tables_catalog_id = "${data.aws_caller_identity.current.account_id}:s3tablescatalog"
+  glue_arn_prefix              = "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}"
+  s3tables_catalog_id          = "${data.aws_caller_identity.current.account_id}:s3tablescatalog"
+  s3tables_bucket_wildcard_arn = "arn:aws:s3tables:${var.aws_region}:${data.aws_caller_identity.current.account_id}:bucket/*"
+
+  # Shared Glue catalog ARN list for the StarRocks S3 Tables federated catalog
+  # (catalog / catalog/s3tablescatalog / per-bucket catalog / database / table).
+  # Guarded by enable_ai_lake since it indexes into the count-gated table bucket.
+  glue_s3tables_catalog_arns = var.enable_ai_lake ? [
+    "${local.glue_arn_prefix}:catalog",
+    "${local.glue_arn_prefix}:catalog/s3tablescatalog",
+    "${local.glue_arn_prefix}:catalog/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}",
+    "${local.glue_arn_prefix}:database/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*",
+    "${local.glue_arn_prefix}:table/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*/*",
+  ] : []
+
+  # Shared two-statement (list+location, then object read/write/multipart) IAM
+  # policy JSON shape used by the gdcn, observability and starrocks S3 access
+  # policies below; only the per-consumer Resource lists differ. The starrocks
+  # ARNs are guarded by enable_ai_lake since the bucket is count-gated.
+  s3_rw_policy_json = {
+    for name, cfg in {
+      gdcn = {
+        bucket_arns = local.gdcn_s3_bucket_arns
+        object_arns = local.gdcn_s3_object_arns
+      }
+      observability = {
+        bucket_arns = local.obs_s3_bucket_arns
+        object_arns = local.obs_s3_object_arns
+      }
+      starrocks = {
+        bucket_arns = var.enable_ai_lake ? [aws_s3_bucket.starrocks[0].arn] : []
+        object_arns = var.enable_ai_lake ? ["${aws_s3_bucket.starrocks[0].arn}/*"] : []
+      }
+      } : name => jsonencode({
+        Version = "2012-10-17",
+        Statement = [
+          {
+            Sid    = "AllowBucketListingAndLocation",
+            Effect = "Allow",
+            Action = [
+              "s3:ListBucket",
+              "s3:GetBucketLocation",
+              "s3:ListBucketMultipartUploads"
+            ],
+            Resource = cfg.bucket_arns
+          },
+          {
+            Sid    = "AllowObjectReadWriteAndMultipart",
+            Effect = "Allow",
+            Action = [
+              "s3:GetObject",
+              "s3:PutObject",
+              "s3:DeleteObject",
+              "s3:AbortMultipartUpload",
+              "s3:ListMultipartUploadParts"
+            ],
+            Resource = cfg.object_arns
+          }
+        ]
+    })
+  }
 }
 
 ###
@@ -129,33 +188,7 @@ resource "aws_iam_policy" "starrocks_s3_access" {
   name        = "${var.deployment_name}-StarRocksS3Access"
   description = "Allow StarRocks workloads to use S3 bucket for shared-data storage."
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowBucketListingAndLocation",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:ListBucketMultipartUploads"
-        ],
-        Resource = [aws_s3_bucket.starrocks[0].arn]
-      },
-      {
-        Sid    = "AllowObjectReadWriteAndMultipart",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListMultipartUploadParts"
-        ],
-        Resource = ["${aws_s3_bucket.starrocks[0].arn}/*"]
-      }
-    ]
-  })
+  policy = local.s3_rw_policy_json["starrocks"]
 }
 
 ###
@@ -279,33 +312,7 @@ resource "aws_iam_policy" "gdcn_s3_access" {
   name        = "${var.deployment_name}-GoodDataCNS3Access"
   description = "Allow GoodData.CN workloads to use S3 buckets for quiver cache, datasource FS, and exports."
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowBucketListingAndLocation",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:ListBucketMultipartUploads"
-        ],
-        Resource = local.gdcn_s3_bucket_arns
-      },
-      {
-        Sid    = "AllowObjectReadWriteAndMultipart",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListMultipartUploadParts"
-        ],
-        Resource = local.gdcn_s3_object_arns
-      }
-    ]
-  })
+  policy = local.s3_rw_policy_json["gdcn"]
 }
 
 ###
@@ -367,31 +374,5 @@ resource "aws_iam_policy" "observability_s3_access" {
   name        = "${var.deployment_name}-ObservabilityS3Access"
   description = "Allow Loki and Tempo to use S3 buckets for object storage."
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowBucketListingAndLocation",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:ListBucketMultipartUploads"
-        ],
-        Resource = local.obs_s3_bucket_arns
-      },
-      {
-        Sid    = "AllowObjectReadWriteAndMultipart",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListMultipartUploadParts"
-        ],
-        Resource = local.obs_s3_object_arns
-      }
-    ]
-  })
+  policy = local.s3_rw_policy_json["observability"]
 }

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -144,9 +144,9 @@ gdcn_orgs = [
 # GoodData AI Lake (optional)
 ###
 # Uncomment to deploy AI Lake (additional license required). Both lines are
-# required; starrocks_size_profile is one of: dev, prod-small, prod-xl.
-# enable_ai_lake         = true
-# starrocks_size_profile = "prod-small"
+# required; ai_lake_size_profile is one of: dev, prod-small, prod-xl.
+# enable_ai_lake       = true
+# ai_lake_size_profile = "prod-small"
 
 ###
 # EKS & infrastructure (optional)

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -33,8 +33,8 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 #       replicaCount: 3
 # EOT
 
-# Uncomment to deploy and enable GoodData generative AI services
-# enable_ai_features = true
+# Uncomment to disable GoodData generative AI services
+# enable_ai_features = false
 
 # Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
@@ -128,9 +128,9 @@ gdcn_orgs = [
 
 # Uncomment to override data retention (defaults shown). Loki/Tempo store data
 # in S3, so retention bounds bucket usage. Loki needs a multiple of 24h.
-# loki_retention_period       = "168h"
+# loki_retention_period       = "720h"
 # prometheus_retention_period = "168h"
-# tempo_retention_period      = "168h"
+# tempo_retention_period      = "720h"
 
 ###
 # Container image caching (optional)
@@ -157,8 +157,10 @@ gdcn_orgs = [
 # eks_endpoint_public_access_cidrs = ["x.x.x.x/32"]
 # eks_endpoint_private_access      = false
 
-# Uncomment to override RDS defaults. apply_immediately reboots the DB to apply
-# changes (e.g. an instance-class change) instead of waiting for maintenance.
-# rds_apply_immediately   = false
-# rds_deletion_protection = false
-# rds_skip_final_snapshot = true
+# Uncomment to override RDS defaults. These follow size_profile: prod keeps
+# deletion protection and takes a final snapshot on destroy. apply_immediately
+# reboots the DB instead of waiting for the maintenance window.
+# rds_apply_immediately       = false
+# rds_backup_retention_period = 14
+# rds_deletion_protection     = true
+# rds_skip_final_snapshot     = false

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -157,9 +157,14 @@ gdcn_orgs = [
 # eks_endpoint_public_access_cidrs = ["x.x.x.x/32"]
 # eks_endpoint_private_access      = false
 
-# Uncomment to override RDS defaults. These follow size_profile: prod keeps
-# deletion protection and takes a final snapshot on destroy. apply_immediately
-# reboots the DB instead of waiting for the maintenance window.
+# Uncomment to override RDS defaults. Left unset these follow size_profile:
+# prod keeps deletion protection and takes a final snapshot on destroy, dev does
+# neither. apply_immediately reboots the DB instead of waiting for the
+# maintenance window.
+#
+# With deletion protection on, `terraform destroy` fails until you first apply
+# with rds_deletion_protection = false. Set rds_skip_final_snapshot = false only
+# when you want that snapshot kept after the instance is gone.
 # rds_apply_immediately       = false
 # rds_backup_retention_period = 14
 # rds_deletion_protection     = true

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -121,8 +121,8 @@ locals {
   eks_node_cpu_max = coalesce(var.eks_node_cpu_max, local.profile.node_cpu_max)
   # StorageClass for GoodData.CN chart PVCs. Overridable via var.eks_storage_class.
   storage_class = coalesce(var.eks_storage_class, local.profile.storage_class)
-  # Class for latency-sensitive PVCs, etcd only for now. Its 5000 IOPS need a
-  # volume of at least 10 GiB, since gp3 caps provisioned IOPS at 500/GiB.
+  # Class for latency-sensitive PVCs, etcd only for now. Differs from the default
+  # class by throughput, at an IOPS level valid for any volume size.
   fast_storage_class = local.profile.fast_storage_class
 
   # AI Lake node types come from var.ai_lake_size_profile, not size_profile.

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -1,9 +1,9 @@
 ###
-# Single source of truth for AWS sizing per size_profile: managed infra (RDS,
-# EKS nodes, Karpenter node CPU ceiling, ingress replicas) inline, plus workload
-# (GoodData.CN/Pulsar/observability) sizing referenced by name. StarRocks (AI
-# Lake) is sized separately via var.starrocks_size_profile. Override any managed
-# value via the matching var.* input.
+# All AWS sizing per size_profile. Managed infra (RDS, EKS system nodes,
+# Karpenter vCPU bounds, ingress replicas) is defined inline; GoodData.CN,
+# Pulsar and observability sizing is referenced by name. AI Lake has its own
+# tier, var.ai_lake_size_profile. Any managed value can be
+# overridden by the matching var.* input.
 ###
 
 locals {
@@ -13,11 +13,13 @@ locals {
         instance_class    = "db.t4g.medium"
         allocated_storage = 20
       }
-      system_node_type = "m6a.xlarge"
-      node_cpu_limit   = 48
-      node_cpu_max     = 8
-      ingress_replicas = 1
-      storage_class    = "gp3"
+      system_node_type   = "m6a.xlarge"
+      system_node_count  = 1
+      node_cpu_limit     = 48
+      node_cpu_max       = 8
+      ingress_replicas   = 1
+      storage_class      = "gp3"
+      fast_storage_class = "gp3"
       postgres = {
         work_mem_mb             = 8
         maintenance_work_mem_mb = 128
@@ -31,11 +33,13 @@ locals {
         instance_class    = "db.r6g.large"
         allocated_storage = 100
       }
-      system_node_type = "m8a.xlarge"
-      node_cpu_limit   = 96
-      node_cpu_max     = 8
-      ingress_replicas = 2
-      storage_class    = "gp3-perf"
+      system_node_type   = "m8a.xlarge"
+      system_node_count  = 2
+      node_cpu_limit     = 96
+      node_cpu_max       = 8
+      ingress_replicas   = 2
+      storage_class      = "gp3"
+      fast_storage_class = "gp3-perf"
       postgres = {
         work_mem_mb             = 16
         maintenance_work_mem_mb = 256
@@ -49,11 +53,13 @@ locals {
         instance_class    = "db.r6g.xlarge"
         allocated_storage = 100
       }
-      system_node_type = "m8a.xlarge"
-      node_cpu_limit   = 320
-      node_cpu_max     = 16
-      ingress_replicas = 3
-      storage_class    = "gp3-perf"
+      system_node_type   = "m8a.xlarge"
+      system_node_count  = 3
+      node_cpu_limit     = 320
+      node_cpu_max       = 16
+      ingress_replicas   = 3
+      storage_class      = "gp3"
+      fast_storage_class = "gp3-perf"
       postgres = {
         work_mem_mb             = 32
         maintenance_work_mem_mb = 512
@@ -65,29 +71,29 @@ locals {
     prod-xl = {
       rds = {
         instance_class    = "db.r6g.2xlarge"
-        allocated_storage = 200
+        allocated_storage = 100
       }
-      system_node_type = "m8a.xlarge"
-      node_cpu_limit   = 480
-      node_cpu_max     = 16
-      ingress_replicas = 3
-      storage_class    = "gp3-perf"
+      system_node_type   = "m8a.xlarge"
+      system_node_count  = 3
+      node_cpu_limit     = 480
+      node_cpu_max       = 16
+      ingress_replicas   = 3
+      storage_class      = "gp3"
+      fast_storage_class = "gp3-perf"
       postgres = {
         work_mem_mb             = 64
         maintenance_work_mem_mb = 1024
       }
-      # No prod-xl GDCN/Pulsar/observability spec; fold to prod-large (explicit).
+      # There is no prod-xl workload spec, so prod-xl reuses prod-large.
       gdcn_size          = "prod-large"
       pulsar_size        = "prod-large"
       observability_size = "prod-large"
     }
   }
 
-  # StarRocks node pools are a separate dimension from size_profile: they are
-  # selected by var.starrocks_size_profile (dev/prod-small/prod-xl), which is
-  # decoupled from size_profile, so they live in their own map keyed only by the
-  # valid StarRocks tiers. There is intentionally no prod-large entry.
-  starrocks_node_type_presets = {
+  # Keyed by var.ai_lake_size_profile, which is chosen independently of
+  # size_profile. Only dev/prod-small/prod-xl exist; prod-large has no tier.
+  ai_lake_node_type_presets = {
     dev        = ["r8a.large", "m8a.xlarge"]
     prod-small = ["r8a.large", "r8a.xlarge"]
     prod-xl    = ["r8a.large", "r8a.8xlarge"]
@@ -95,28 +101,31 @@ locals {
 
   profile = local.size_profiles[var.size_profile]
 
-  # Resolved size_profile values (profile default, overridable via var.*).
+  # Resolved values: profile default unless the matching var.* is set.
   rds_instance_class    = coalesce(var.rds_instance_class, local.profile.rds.instance_class)
   rds_allocated_storage = coalesce(var.rds_allocated_storage, local.profile.rds.allocated_storage)
-  # Prod tiers get deletion protection and a final snapshot on destroy; dev stays
-  # disposable. PITR is 14 days for prod, 7 for dev. Overridable via var.*.
+  # Prod keeps deletion protection, a final snapshot on destroy, and 14 days of
+  # point-in-time recovery; dev is disposable and keeps 7 days.
   rds_is_prod                 = startswith(var.size_profile, "prod")
   rds_deletion_protection     = var.rds_deletion_protection != null ? var.rds_deletion_protection : local.rds_is_prod
   rds_skip_final_snapshot     = var.rds_skip_final_snapshot != null ? var.rds_skip_final_snapshot : !local.rds_is_prod
   rds_backup_retention_period = coalesce(var.rds_backup_retention_period, local.rds_is_prod ? 14 : 7)
-  # System node group instance type (not user-configurable). Workload nodes are
-  # sized by Karpenter (instance-category + CPU bounds below).
-  system_node_type = local.profile.system_node_type
-  # Total workload vCPU ceiling (NodePool spec.limits.cpu).
+  # Instance type and count of the system node group; not user-configurable.
+  # Karpenter sizes the workload nodes, using the vCPU bounds below.
+  system_node_type  = local.profile.system_node_type
+  system_node_count = local.profile.system_node_count
+  # Ceiling on total workload vCPUs Karpenter may run (NodePool spec.limits.cpu).
   eks_node_cpu_limit = coalesce(var.eks_node_cpu_limit, local.profile.node_cpu_limit)
-  # Per-node vCPU cap for workload nodes (NodePool instance-cpu Lt) within the m category.
+  # Largest workload node Karpenter may pick, in vCPUs (NodePool instance-cpu Lt).
+  # The m*a types it selects from have no member below 2 vCPU, so no floor is set.
   eks_node_cpu_max = coalesce(var.eks_node_cpu_max, local.profile.node_cpu_max)
-  # StorageClass for GoodData.CN chart PVCs (gp3 for dev, gp3-perf for prod).
-  # Overridable via var.eks_storage_class.
+  # StorageClass for GoodData.CN chart PVCs. Overridable via var.eks_storage_class.
   storage_class = coalesce(var.eks_storage_class, local.profile.storage_class)
+  # Class for latency-sensitive PVCs, etcd only for now. Its 5000 IOPS need a
+  # volume of at least 10 GiB, since gp3 caps provisioned IOPS at 500/GiB.
+  fast_storage_class = local.profile.fast_storage_class
 
-  # StarRocks node pool: indexed by the explicit var.starrocks_size_profile, NOT
-  # size_profile (the two are decoupled). Only used when enable_ai_lake is true,
-  # which the variable's validation requires.
-  eks_starrocks_node_types = var.enable_ai_lake ? coalesce(var.eks_starrocks_node_types, local.starrocks_node_type_presets[var.starrocks_size_profile]) : []
+  # AI Lake node types come from var.ai_lake_size_profile, not size_profile.
+  # Empty unless AI Lake is enabled, since nothing consumes them otherwise.
+  eks_ai_lake_node_types = var.enable_ai_lake ? coalesce(var.eks_ai_lake_node_types, local.ai_lake_node_type_presets[var.ai_lake_size_profile]) : []
 }

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -98,6 +98,12 @@ locals {
   # Resolved size_profile values (profile default, overridable via var.*).
   rds_instance_class    = coalesce(var.rds_instance_class, local.profile.rds.instance_class)
   rds_allocated_storage = coalesce(var.rds_allocated_storage, local.profile.rds.allocated_storage)
+  # Prod tiers get deletion protection and a final snapshot on destroy; dev stays
+  # disposable. PITR is 14 days for prod, 7 for dev. Overridable via var.*.
+  rds_is_prod                 = startswith(var.size_profile, "prod")
+  rds_deletion_protection     = var.rds_deletion_protection != null ? var.rds_deletion_protection : local.rds_is_prod
+  rds_skip_final_snapshot     = var.rds_skip_final_snapshot != null ? var.rds_skip_final_snapshot : !local.rds_is_prod
+  rds_backup_retention_period = coalesce(var.rds_backup_retention_period, local.rds_is_prod ? 14 : 7)
   # System node group instance type (not user-configurable). Workload nodes are
   # sized by Karpenter (instance-category + CPU bounds below).
   system_node_type = local.profile.system_node_type

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -465,15 +465,19 @@ variable "rds_backup_retention_period" {
   type        = number
   default     = null
   validation {
-    condition     = var.rds_backup_retention_period == null || (var.rds_backup_retention_period >= 0 && var.rds_backup_retention_period <= 35)
-    error_message = "rds_backup_retention_period must be between 0 and 35 days."
+    condition = var.rds_backup_retention_period == null || (
+      floor(var.rds_backup_retention_period) == var.rds_backup_retention_period
+      && var.rds_backup_retention_period >= 0
+      && var.rds_backup_retention_period <= 35
+    )
+    error_message = "rds_backup_retention_period must be a whole number of days between 0 and 35."
   }
 }
 
 variable "rds_deletion_protection" {
-  description = "Enable deletion protection on the RDS instance."
+  description = "Enable deletion protection on the RDS instance. If null, chosen by size_profile (on for prod, off for dev)."
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "rds_instance_class" {
@@ -483,9 +487,9 @@ variable "rds_instance_class" {
 }
 
 variable "rds_skip_final_snapshot" {
-  description = "Skip taking a final snapshot when destroying the RDS instance."
+  description = "Skip taking a final snapshot when destroying the RDS instance. If null, chosen by size_profile (final snapshot for prod, skipped for dev)."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "route53_zone_id" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,3 +1,17 @@
+variable "ai_lake_size_profile" {
+  description = "AI Lake sizing profile. Required when enable_ai_lake is true; one of: dev, prod-small, prod-xl. Not derived from size_profile."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.ai_lake_size_profile == null || contains(["dev", "prod-small", "prod-xl"], var.ai_lake_size_profile)
+    error_message = "ai_lake_size_profile must be one of: dev, prod-small, prod-xl."
+  }
+  validation {
+    condition     = !var.enable_ai_lake || var.ai_lake_size_profile != null
+    error_message = "ai_lake_size_profile must be set when enable_ai_lake is true."
+  }
+}
+
 variable "auth_hostname" {
   description = "Hostname for the default GoodData identity provider (Dex) ingress."
   type        = string
@@ -66,6 +80,12 @@ variable "dockerhub_username" {
   }
 }
 
+variable "eks_ai_lake_node_types" {
+  description = "EC2 instance types for the dedicated AI Lake node pool (taint workload=starrocks). If null, defaults to a preset chosen by ai_lake_size_profile."
+  type        = list(string)
+  default     = null
+}
+
 variable "eks_endpoint_private_access" {
   description = "Whether the EKS API server is reachable privately from within the VPC."
   type        = bool
@@ -100,14 +120,20 @@ variable "eks_node_cpu_max" {
   default     = null
 }
 
-variable "eks_starrocks_node_types" {
-  description = "EC2 instance types for the StarRocks-dedicated EKS pool (taint workload=starrocks). If null, defaults to a preset chosen by starrocks_size_profile."
-  type        = list(string)
-  default     = null
+variable "eks_node_disk_size" {
+  description = "Data volume size in GiB for every node's /dev/xvdb, on both the system node group and the Karpenter EC2NodeClass. Bottlerocket otherwise defaults to 20 GiB, which is below the ephemeral-storage some GoodData.CN pods request and leaves them unschedulable on every instance type."
+  type        = number
+  default     = 100
+}
+
+variable "eks_node_max_pods" {
+  description = "Kubelet maxPods for every node, set on the Karpenter EC2NodeClass and in the system node group's Bottlerocket settings. Both otherwise derive it from the instance type's secondary-IP limits, which leaves VPC CNI prefix delegation inert. 110 is the AWS-recommended ceiling for instances under 30 vCPU."
+  type        = number
+  default     = 110
 }
 
 variable "eks_storage_class" {
-  description = "Kubernetes StorageClass for GoodData.CN chart PVCs. If null, chosen by size_profile (gp3 for dev, gp3-perf for prod)."
+  description = "Kubernetes StorageClass for GoodData.CN chart PVCs. If null, chosen by size_profile. Latency-sensitive PVCs use the fast class instead, which is not user-configurable."
   type        = string
   default     = null
 }
@@ -143,7 +169,7 @@ variable "enable_observability" {
 }
 
 variable "enable_ai_lake" {
-  description = "Enable StarRocks deployment for analytics query acceleration"
+  description = "Enable AI Lake deployment for analytics query acceleration"
   type        = bool
   default     = false
 }
@@ -492,20 +518,6 @@ variable "starrocks_fe_image_tag" {
   description = "Docker image tag for StarRocks FE nodes"
   type        = string
   default     = "4.0.6-20260507-091022-3c12ee9"
-}
-
-variable "starrocks_size_profile" {
-  description = "StarRocks (AI Lake) sizing profile. Required when enable_ai_lake is true; one of: dev, prod-small, prod-xl. Not derived from size_profile."
-  type        = string
-  default     = null
-  validation {
-    condition     = var.starrocks_size_profile == null || contains(["dev", "prod-small", "prod-xl"], var.starrocks_size_profile)
-    error_message = "starrocks_size_profile must be one of: dev, prod-small, prod-xl."
-  }
-  validation {
-    condition     = !var.enable_ai_lake || var.starrocks_size_profile != null
-    error_message = "starrocks_size_profile must be set when enable_ai_lake is true."
-  }
 }
 
 variable "tls_mode" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -434,6 +434,16 @@ variable "rds_apply_immediately" {
   default     = false
 }
 
+variable "rds_backup_retention_period" {
+  description = "Days of automated RDS backups / point-in-time recovery. If null, chosen by size_profile (14 for prod, 7 for dev)."
+  type        = number
+  default     = null
+  validation {
+    condition     = var.rds_backup_retention_period == null || (var.rds_backup_retention_period >= 0 && var.rds_backup_retention_period <= 35)
+    error_message = "rds_backup_retention_period must be between 0 and 35 days."
+  }
+}
+
 variable "rds_deletion_protection" {
   description = "Enable deletion protection on the RDS instance."
   type        = bool

--- a/aws/vpc-endpoints.tf
+++ b/aws/vpc-endpoints.tf
@@ -3,7 +3,7 @@
 ###
 
 # S3 gateway endpoint: routes S3 traffic (Quiver cache, datasource FS, exports,
-# StarRocks) over the AWS backbone instead of the NAT gateway, eliminating NAT
+# AI Lake) over the AWS backbone instead of the NAT gateway, eliminating NAT
 # data-processing charges on blob I/O. Gateway endpoints are free. Only created
 # for VPCs we manage; bring-your-own-VPC users add their own.
 resource "aws_vpc_endpoint" "s3" {

--- a/azure/aks.tf
+++ b/azure/aks.tf
@@ -91,9 +91,12 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   tags = local.common_tags
 
-  # NAT gateway must be attached to the subnet before the cluster is created
-  # when outbound_type = userAssignedNATGateway.
-  depends_on = [azurerm_subnet_nat_gateway_association.aks]
+  # userAssignedNATGateway egress needs both bound before creation, and keeps node
+  # egress alive until the cluster is destroyed.
+  depends_on = [
+    azurerm_nat_gateway_public_ip_association.main,
+    azurerm_subnet_nat_gateway_association.aks,
+  ]
 }
 
 # The kubelet identity gets no resource-group-wide grant: any pod can reach it

--- a/azure/aks.tf
+++ b/azure/aks.tf
@@ -56,11 +56,10 @@ resource "azurerm_kubernetes_cluster" "main" {
     tags = local.common_tags
   }
 
-  # Node Auto Provisioning (NAP / managed Karpenter) replaces the cluster
-  # autoscaler. mode=Auto installs and manages Karpenter in the control plane;
-  # default_node_pools=None means the only NodePools are the ones we define
-  # ourselves (see karpenter.tf). NAP cannot coexist with the cluster
-  # autoscaler, so node-pool autoscaling and auto_scaler_profile are removed.
+  # Node Auto Provisioning (NAP / managed Karpenter): mode=Auto installs and
+  # manages Karpenter in the control plane; default_node_pools=None means the
+  # only NodePools are the ones we define (karpenter.tf). NAP cannot coexist
+  # with the cluster autoscaler, so node-pool autoscaling must stay unset.
   node_provisioning_profile {
     mode               = "Auto"
     default_node_pools = "None"
@@ -72,7 +71,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   # Azure CNI Overlay powered by Cilium: pods get IPs from pod_cidr, not the AKS
-  # subnet, so node count is no longer subnet-bound. Overlay requires Cilium (not NPM).
+  # subnet, so node count isn't subnet-bound. Overlay requires Cilium (not NPM).
   network_profile {
     network_plugin      = "azure"
     network_plugin_mode = "overlay"
@@ -97,12 +96,8 @@ resource "azurerm_kubernetes_cluster" "main" {
   depends_on = [azurerm_subnet_nat_gateway_association.aks]
 }
 
-# Grant AKS cluster permissions to manage the resource group
-resource "azurerm_role_assignment" "aks_cluster_contributor" {
-  scope                = azurerm_resource_group.main.id
-  role_definition_name = "Contributor"
-  principal_id         = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
-}
+# The kubelet identity gets no resource-group-wide grant: any pod can reach it
+# via IMDS. Real needs use scoped identities (AcrPull below, UAMIs in identity.tf).
 
 # Grant AKS cluster's system identity Network Contributor permissions for LoadBalancer services
 resource "azurerm_role_assignment" "aks_system_identity_network_contributor" {

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -126,6 +126,12 @@ module "k8s_common" {
     # DNS must resolve before cert-manager issues its first Let's Encrypt cert;
     # a failed issuance backs off up to 32h. No-op unless dns_provider=azure-dns.
     helm_release.external_dns,
+    # Node capacity must outlive the helm releases too: deleting the NodePool
+    # taints every Karpenter node, leaving pre-delete hooks unschedulable.
+    kubectl_manifest.karpenter_node_pool,
+    # Deleting a LoadBalancer Service needs subnet join, so this grant must
+    # outlive the ingress release or the Azure LB can never be torn down.
+    azurerm_role_assignment.aks_system_identity_network_contributor,
   ]
 }
 

--- a/azure/karpenter.tf
+++ b/azure/karpenter.tf
@@ -22,7 +22,10 @@ resource "kubectl_manifest" "karpenter_node_class" {
     }
   })
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }
 
 # General-purpose NodePool: on-demand AMD general-purpose D-series with a

--- a/azure/karpenter.tf
+++ b/azure/karpenter.tf
@@ -56,6 +56,8 @@ resource "kubectl_manifest" "karpenter_node_pool" {
             { key = "karpenter.sh/capacity-type", operator = "In", values = ["on-demand"] },
             # AMD general-purpose, 4 GiB/vCPU, premium-capable D-series only.
             # Excludes Intel (Ds/Dls), low-memory (Dals/Dls), and ARM (Dpls).
+            # Smallest member (D2as) gives an implicit 2 vCPU floor, matching the
+            # explicit eks_node_cpu_min on AWS; no Gt requirement needed here.
             { key = "karpenter.azure.com/sku-series", operator = "In", values = ["Das_v5", "Das_v6", "Das_v7"] },
             { key = "karpenter.azure.com/sku-cpu", operator = "Lt", values = [tostring(local.aks_node_cpu_max + 1)] },
             # Belt-and-suspenders: the series above are all premium-capable, but

--- a/azure/karpenter.tf
+++ b/azure/karpenter.tf
@@ -37,9 +37,8 @@ resource "kubectl_manifest" "karpenter_node_class" {
 # All listed series are premium-storage capable, which in Azure costs the same
 # per hour as the (now v4-only) non-premium variants, so there is no reason to
 # admit non-premium SKUs and force premium-PVC pods onto per-pod nodeAffinity.
-# Spanning v5-v7 keeps a wide capacity pool; Karpenter prefers the cheapest
-# (v6/v7) and falls back to v5 only on shortage. sku-cpu + the CPU limit bound
-# node size and total cost.
+# v6/v7 only, so nodes are always current-generation. sku-cpu + the CPU limit
+# bound node size and total cost.
 resource "kubectl_manifest" "karpenter_node_pool" {
   yaml_body = yamlencode({
     apiVersion = "karpenter.sh/v1"
@@ -56,9 +55,9 @@ resource "kubectl_manifest" "karpenter_node_pool" {
             { key = "karpenter.sh/capacity-type", operator = "In", values = ["on-demand"] },
             # AMD general-purpose, 4 GiB/vCPU, premium-capable D-series only.
             # Excludes Intel (Ds/Dls), low-memory (Dals/Dls), and ARM (Dpls).
-            # Smallest member (D2as) gives an implicit 2 vCPU floor, matching the
-            # explicit eks_node_cpu_min on AWS; no Gt requirement needed here.
-            { key = "karpenter.azure.com/sku-series", operator = "In", values = ["Das_v5", "Das_v6", "Das_v7"] },
+            # Smallest member (D2as) gives an implicit 2 vCPU floor, so no Gt
+            # requirement is needed here.
+            { key = "karpenter.azure.com/sku-series", operator = "In", values = ["Das_v6", "Das_v7"] },
             { key = "karpenter.azure.com/sku-cpu", operator = "Lt", values = [tostring(local.aks_node_cpu_max + 1)] },
             # Belt-and-suspenders: the series above are all premium-capable, but
             # keep this so a stray non-premium series can never admit a node that

--- a/azure/postgresql.tf
+++ b/azure/postgresql.tf
@@ -44,6 +44,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   administrator_login    = local.db_username
   administrator_password = local.db_password
   storage_mb             = local.postgresql_storage_mb
+  storage_tier           = local.postgresql_storage_tier
   sku_name               = local.postgresql_sku_name
 
   # Disable public network access when using VNet integration

--- a/azure/postgresql.tf
+++ b/azure/postgresql.tf
@@ -49,8 +49,11 @@ resource "azurerm_postgresql_flexible_server" "main" {
   # Disable public network access when using VNet integration
   public_network_access_enabled = false
 
-  backup_retention_days = 7
+  backup_retention_days = local.postgresql_backup_retention_days
   auto_grow_enabled     = true
+  # Backups in the paired region. Opt-in, not profile-derived: Azure only accepts
+  # this at create time, so changing it recreates the server (destroying the DB).
+  geo_redundant_backup_enabled = var.postgresql_geo_redundant_backup
 
   maintenance_window {
     day_of_week  = 0

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -30,8 +30,8 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 #       replicaCount: 3
 # EOT
 
-# Uncomment to deploy and enable GoodData generative AI services
-# enable_ai_features = true
+# Uncomment to disable GoodData generative AI services
+# enable_ai_features = false
 
 # Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
@@ -76,8 +76,8 @@ dns_provider = "self-managed"
 
 # Option 1 — NGINX Ingress Controller (ingress-nginx) + Let's Encrypt certificates (letsencrypt)
 ingress_controller = "ingress-nginx"
-tls_mode          = "letsencrypt"
-letsencrypt_email = "me@example.com"
+tls_mode           = "letsencrypt"
+letsencrypt_email  = "me@example.com"
 
 # Uncomment when ingress-nginx sits behind another L7 proxy/load balancer.
 # ingress_nginx_behind_l7 = true
@@ -123,9 +123,9 @@ gdcn_orgs = [
 
 # Uncomment to override data retention (defaults shown). Loki/Tempo store data
 # in Azure Blob, so retention bounds container usage. Loki needs a multiple of 24h.
-# loki_retention_period       = "168h"
+# loki_retention_period       = "720h"
 # prometheus_retention_period = "168h"
-# tempo_retention_period      = "168h"
+# tempo_retention_period      = "720h"
 
 ###
 # Container image caching (optional)
@@ -141,3 +141,6 @@ gdcn_orgs = [
 # Uncomment to override AKS defaults
 # aks_version                         = "1.36"
 # aks_api_server_authorized_ip_ranges = ["x.x.x.x/32"]
+
+# Uncomment to replicate backups to the Azure paired region.
+# postgresql_geo_redundant_backup = true

--- a/azure/size-profiles.tf
+++ b/azure/size-profiles.tf
@@ -79,7 +79,10 @@ locals {
   # Resolved managed values (profile default, overridable via var.*).
   postgresql_sku_name   = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
   postgresql_storage_mb = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
-  aks_min_nodes         = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
+  # Prod tiers get a 14-day PITR window, dev keeps the 7-day minimum.
+  postgresql_is_prod               = startswith(var.size_profile, "prod")
+  postgresql_backup_retention_days = coalesce(var.postgresql_backup_retention_days, local.postgresql_is_prod ? 14 : 7)
+  aks_min_nodes                    = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
   # System pool VM size (not user-configurable). Workload nodes are sized by
   # Karpenter (sku-family + CPU bounds below).
   system_node_vm_size = local.profile.system_node_vm_size

--- a/azure/size-profiles.tf
+++ b/azure/size-profiles.tf
@@ -1,16 +1,17 @@
 ###
-# Single source of truth for Azure sizing per size_profile: managed infra
-# (PostgreSQL, AKS nodes, Karpenter/NAP node CPU ceiling, ingress replicas) inline, plus
-# workload (GoodData.CN/Pulsar/observability) sizing referenced by name. prod-xl
-# is not valid on Azure. Override any managed value via the matching var.* input.
+# All Azure sizing per size_profile. Managed infra (PostgreSQL, AKS system
+# nodes, Karpenter/NAP vCPU bounds, ingress replicas) is defined inline;
+# GoodData.CN, Pulsar and observability sizing is referenced by name. prod-xl
+# is AWS-only. Any managed value can be overridden by the matching var.* input.
 ###
 
 locals {
   size_profiles = {
     dev = {
       postgresql = {
-        sku_name   = "B_Standard_B2s"
-        storage_mb = 32768
+        sku_name     = "B_Standard_B2s"
+        storage_mb   = 32768
+        storage_tier = null
       }
       postgres = {
         work_mem_mb             = 8
@@ -20,8 +21,8 @@ locals {
       aks_node_counts = {
         min = 1
       }
-      node_cpu_limit     = 24
-      node_cpu_max       = 4
+      node_cpu_limit     = 48
+      node_cpu_max       = 8
       storage_class      = "managed-csi"
       ingress_replicas   = 1
       gdcn_size          = "dev"
@@ -30,8 +31,11 @@ locals {
     }
     prod-small = {
       postgresql = {
-        sku_name   = "GP_Standard_D4ds_v5"
-        storage_mb = 131072
+        sku_name = "GP_Standard_D4ds_v5"
+        # 128 GB is the smallest step at or above 100 GB; autogrow (postgresql.tf)
+        # grows it. P20 pins ~2300 IOPS, which untiered storage needs 512 GB for.
+        storage_mb   = 131072
+        storage_tier = "P20"
       }
       postgres = {
         work_mem_mb             = 16
@@ -51,10 +55,9 @@ locals {
     }
     prod-large = {
       postgresql = {
-        sku_name = "MO_Standard_E8ds_v5"
-        # 512 GB for IOPS headroom under load (v1 storage IOPS scale with size:
-        # ~2300 @ 512 GB vs ~500 @ 128 GB). Overridable via var.postgresql_storage_mb.
-        storage_mb = 524288
+        sku_name     = "MO_Standard_E8ds_v5"
+        storage_mb   = 131072
+        storage_tier = "P20"
       }
       postgres = {
         work_mem_mb             = 32
@@ -76,21 +79,26 @@ locals {
 
   profile = local.size_profiles[var.size_profile]
 
-  # Resolved managed values (profile default, overridable via var.*).
-  postgresql_sku_name   = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
-  postgresql_storage_mb = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
-  # Prod tiers get a 14-day PITR window, dev keeps the 7-day minimum.
+  # Resolved values: profile default unless the matching var.* is set.
+  postgresql_sku_name = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
+  # Disk size and its performance tier; not user-configurable, since Azure
+  # rejects a tier below the one its size implies. dev leaves the tier null so
+  # Azure derives it; prod pins P20 to get IOPS without a bigger disk.
+  postgresql_storage_mb   = local.profile.postgresql.storage_mb
+  postgresql_storage_tier = local.profile.postgresql.storage_tier
+  # Prod keeps 14 days of point-in-time recovery, dev the 7-day minimum.
   postgresql_is_prod               = startswith(var.size_profile, "prod")
   postgresql_backup_retention_days = coalesce(var.postgresql_backup_retention_days, local.postgresql_is_prod ? 14 : 7)
   aks_min_nodes                    = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
-  # System pool VM size (not user-configurable). Workload nodes are sized by
-  # Karpenter (sku-family + CPU bounds below).
+  # VM size of the system pool; not user-configurable. Karpenter sizes the
+  # workload nodes, using the vCPU bounds below.
   system_node_vm_size = local.profile.system_node_vm_size
-  # Total workload vCPU ceiling (NodePool spec.limits.cpu).
+  # Ceiling on total workload vCPUs Karpenter may run (NodePool spec.limits.cpu).
   aks_node_cpu_limit = coalesce(var.aks_node_cpu_limit, local.profile.node_cpu_limit)
-  # Per-node vCPU cap for workload nodes (NodePool sku-cpu Lt) within the D family.
+  # Largest workload node Karpenter may pick, in vCPUs (NodePool sku-cpu Lt).
+  # The Das series it selects from has no member below 2 vCPU, so no floor is set.
   aks_node_cpu_max = coalesce(var.aks_node_cpu_max, local.profile.node_cpu_max)
-  # StorageClass for GoodData.CN chart PVCs (standard for dev, premium for prod).
-  # Overridable via var.azure_storage_class.
+  # StorageClass for GoodData.CN chart PVCs: managed-csi on dev,
+  # premium-ssd-v2 on prod.
   storage_class = coalesce(var.azure_storage_class, local.profile.storage_class)
 }

--- a/azure/size-profiles.tf
+++ b/azure/size-profiles.tf
@@ -2,7 +2,8 @@
 # All Azure sizing per size_profile. Managed infra (PostgreSQL, AKS system
 # nodes, Karpenter/NAP vCPU bounds, ingress replicas) is defined inline;
 # GoodData.CN, Pulsar and observability sizing is referenced by name. prod-xl
-# is AWS-only. Any managed value can be overridden by the matching var.* input.
+# is AWS-only. Managed values are overridable by the matching var.* input where
+# one exists; PostgreSQL storage size and tier are profile-fixed (see below).
 ###
 
 locals {

--- a/azure/storage-class.tf
+++ b/azure/storage-class.tf
@@ -28,7 +28,10 @@ resource "kubernetes_storage_class_v1" "premium_ssd_v2" {
     DiskMBpsReadWrite = "125"
   }
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }
 
 # Premium SSD v1 (Premium_LRS) kept as a non-default class so workloads can pin
@@ -51,7 +54,10 @@ resource "kubernetes_storage_class_v1" "premium_ssd" {
     skuname = "Premium_LRS"
   }
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }
 
 # Cluster default = the built-in StandardSSD class "managed-csi" (standard tier).
@@ -81,5 +87,8 @@ resource "kubernetes_annotations" "default_storage_class" {
   # take ownership of it rather than erroring on the conflict.
   force = true
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -376,12 +376,6 @@ variable "postgresql_sku_name" {
   default     = null
 }
 
-variable "postgresql_storage_mb" {
-  description = "Azure Database for PostgreSQL storage in MB. If null, chosen by size_profile."
-  type        = number
-  default     = null
-}
-
 variable "size_profile" {
   description = "Sizing profile for GoodData.CN and supporting services."
   type        = string

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -354,6 +354,22 @@ variable "observability_hostname" {
   }
 }
 
+variable "postgresql_backup_retention_days" {
+  description = "Days of automated PostgreSQL backups / point-in-time recovery. If null, chosen by size_profile (14 for prod, 7 for dev)."
+  type        = number
+  default     = null
+  validation {
+    condition     = var.postgresql_backup_retention_days == null || (var.postgresql_backup_retention_days >= 7 && var.postgresql_backup_retention_days <= 35)
+    error_message = "postgresql_backup_retention_days must be between 7 and 35 days."
+  }
+}
+
+variable "postgresql_geo_redundant_backup" {
+  description = "Replicate PostgreSQL backups to the Azure paired region. Create-time only: changing it on an existing server destroys and recreates the database."
+  type        = bool
+  default     = false
+}
+
 variable "postgresql_sku_name" {
   description = "Azure Database for PostgreSQL SKU name. If null, chosen by size_profile. E.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3"
   type        = string

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -359,8 +359,12 @@ variable "postgresql_backup_retention_days" {
   type        = number
   default     = null
   validation {
-    condition     = var.postgresql_backup_retention_days == null || (var.postgresql_backup_retention_days >= 7 && var.postgresql_backup_retention_days <= 35)
-    error_message = "postgresql_backup_retention_days must be between 7 and 35 days."
+    condition = var.postgresql_backup_retention_days == null || (
+      floor(var.postgresql_backup_retention_days) == var.postgresql_backup_retention_days
+      && var.postgresql_backup_retention_days >= 7
+      && var.postgresql_backup_retention_days <= 35
+    )
+    error_message = "postgresql_backup_retention_days must be a whole number of days between 7 and 35."
   }
 }
 

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -29,8 +29,8 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 #       replicaCount: 3
 # EOT
 
-# Uncomment to deploy and enable GoodData generative AI services
-# enable_ai_features = true
+# Uncomment to disable GoodData generative AI services
+# enable_ai_features = false
 
 # Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
@@ -45,8 +45,8 @@ size_profile = "dev"
 ###
 
 # Option 1 — NGINX Ingress Controller (ingress-nginx) + cert-manager self-signed certificates
-ingress_controller      = "ingress-nginx"
-tls_mode                = "selfsigned"
+ingress_controller = "ingress-nginx"
+tls_mode           = "selfsigned"
 
 # Option 2 — Istio Gateway + cert-manager self-signed certificates
 # ingress_controller = "istio_gateway"

--- a/local/size-profiles.tf
+++ b/local/size-profiles.tf
@@ -1,8 +1,8 @@
 ###
-# Single source of truth for local (k3d) sizing. Local supports only "dev"
-# (smallest, non-HA). Holds the in-cluster postgres (CNPG) sizing inline plus
-# workload (GoodData.CN/Pulsar/observability) sizing referenced by name.
-# StarRocks (AI Lake) is not supported on local.
+# All local (k3d) sizing; "dev" is the only profile local supports. The
+# in-cluster Postgres (CNPG) sizing is defined inline; GoodData.CN, Pulsar and
+# observability sizing is referenced by name. AI Lake is not supported
+# on local.
 ###
 
 locals {

--- a/modules/k8s-aws/external-dns.tf
+++ b/modules/k8s-aws/external-dns.tf
@@ -113,10 +113,16 @@ resource "helm_release" "external_dns" {
   wait_for_jobs = true
   timeout       = 1800
 
+  # Tolerate the system pool taint: this runs before Karpenter has provisioned
+  # any untainted capacity, so the system nodes are the only place it can land.
   values = [yamlencode({
     image = {
       repository = "${var.registry_k8sio}/external-dns/external-dns"
     }
+    tolerations = [{
+      key      = "CriticalAddonsOnly"
+      operator = "Exists"
+    }]
     provider      = "aws"
     policy        = "sync"
     registry      = "txt"

--- a/modules/k8s-aws/lb-controller.tf
+++ b/modules/k8s-aws/lb-controller.tf
@@ -267,6 +267,8 @@ resource "helm_release" "aws_load_balancer_controller" {
   wait_for_jobs = true
   timeout       = 1800
 
+  # Tolerate the system pool taint: this runs before Karpenter has provisioned
+  # any untainted capacity, so the system nodes are the only place it can land.
   values = [<<EOF
     replicaCount: ${var.ingress_replicas}
     clusterName: ${var.deployment_name}
@@ -275,6 +277,9 @@ resource "helm_release" "aws_load_balancer_controller" {
     serviceAccount:
       create: false
       name: aws-load-balancer-controller
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
 EOF
   ]
 

--- a/modules/k8s-aws/metrics-server.tf
+++ b/modules/k8s-aws/metrics-server.tf
@@ -17,9 +17,14 @@ resource "helm_release" "metrics-server" {
   wait          = true
   wait_for_jobs = true
   timeout       = 1800
+  # Tolerate the system pool taint: this runs before Karpenter has provisioned
+  # any untainted capacity, so the system nodes are the only place it can land.
   values = [<<EOF
 image:
   repository: ${var.registry_k8sio}/metrics-server/metrics-server
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
 EOF
   ]
 }

--- a/modules/k8s-aws/storage-class.tf
+++ b/modules/k8s-aws/storage-class.tf
@@ -15,6 +15,8 @@ resource "kubernetes_storage_class_v1" "gp3_perf" {
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
 
+  # Fast class for latency-sensitive PVCs. EBS caps gp3 provisioned IOPS at
+  # 500/GiB, so volumes on this class must be at least 10 GiB.
   parameters = {
     type       = "gp3"
     iops       = "5000"

--- a/modules/k8s-aws/storage-class.tf
+++ b/modules/k8s-aws/storage-class.tf
@@ -2,6 +2,9 @@
 # Configure Kubernetes storage class
 ###
 
+# encrypted = "true" on both classes, so PVC data is encrypted at rest without
+# relying on the account default. Unset kmsKeyId uses the AWS-managed EBS key.
+
 resource "kubernetes_storage_class_v1" "gp3_perf" {
   metadata {
     name = "gp3-perf"
@@ -16,6 +19,7 @@ resource "kubernetes_storage_class_v1" "gp3_perf" {
     type       = "gp3"
     iops       = "5000"
     throughput = "300"
+    encrypted  = "true"
   }
 }
 
@@ -34,6 +38,7 @@ resource "kubernetes_storage_class_v1" "gp3" {
   allow_volume_expansion = true
 
   parameters = {
-    type = "gp3"
+    type      = "gp3"
+    encrypted = "true"
   }
 }

--- a/modules/k8s-aws/storage-class.tf
+++ b/modules/k8s-aws/storage-class.tf
@@ -15,11 +15,12 @@ resource "kubernetes_storage_class_v1" "gp3_perf" {
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
 
-  # Fast class for latency-sensitive PVCs. EBS caps gp3 provisioned IOPS at
-  # 500/GiB, so volumes on this class must be at least 10 GiB.
+  # Fast class for latency-sensitive PVCs. 3000 IOPS is the ceiling valid at any
+  # size; above it EBS caps gp3 provisioned IOPS at 500/GiB. Throughput is the
+  # real gain here: 300 MBps against the 125 the default class gets free.
   parameters = {
     type       = "gp3"
-    iops       = "5000"
+    iops       = "3000"
     throughput = "300"
     encrypted  = "true"
   }

--- a/modules/k8s-common/cert-manager.tf
+++ b/modules/k8s-common/cert-manager.tf
@@ -73,7 +73,7 @@ resource "kubectl_manifest" "letsencrypt_cluster_issuer" {
               local.cert_manager_http01_ingress_class == "nginx" ? {
                 ingressTemplate = {
                   metadata = {
-                    annotations = { "nginx.ingress.kubernetes.io/enable-validate-ingress" = "false" }
+                    annotations = local.cert_manager_http01_ingress_annotations
                   }
                 }
               } : {}

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -10,15 +10,9 @@ locals {
     {
       "nginx.ingress.kubernetes.io/proxy-body-size" = "200m"
     },
-    local.use_cert_manager ? {
-      "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
-    } : {}
+    local.cert_manager_issuer_annotation
   ) : {}
-  dex_annotation_defaults = local.use_ingress_nginx ? (
-    local.use_cert_manager ? {
-      "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
-    } : {}
-  ) : {}
+  dex_annotation_defaults = local.use_ingress_nginx ? local.cert_manager_issuer_annotation : {}
   ingress_annotations     = merge(local.ingress_annotation_defaults, var.ingress_annotations_override)
   dex_ingress_annotations = merge(local.dex_annotation_defaults, var.dex_ingress_annotations_override)
   dex_tls_enabled         = local.use_cert_manager
@@ -43,10 +37,8 @@ resource "kubectl_manifest" "peerauth_gdcn_strict" {
 
 resource "kubernetes_namespace_v1" "gdcn" {
   metadata {
-    name = var.gdcn_namespace
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = var.gdcn_namespace
+    labels = local.istio_injection_labels
   }
 }
 

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -16,6 +16,7 @@ locals {
   ingress_annotations     = merge(local.ingress_annotation_defaults, var.ingress_annotations_override)
   dex_ingress_annotations = merge(local.dex_annotation_defaults, var.dex_ingress_annotations_override)
   dex_tls_enabled         = local.use_cert_manager
+  fast_storage_class      = var.fast_storage_class != "" ? var.fast_storage_class : var.gdcn_storage_class
 }
 
 # Enforce STRICT mTLS for all inbound traffic to workloads in the GoodData.CN namespace.
@@ -122,6 +123,7 @@ resource "helm_release" "gooddata_cn" {
       db_username             = var.db_username
       db_password             = var.db_password
       storage_class           = var.gdcn_storage_class
+      fast_storage_class      = local.fast_storage_class
       registry_dockerio       = var.registry_dockerio
       registry_quayio         = var.registry_quayio
       ingress_class_name      = local.resolved_ingress_class_name
@@ -160,7 +162,7 @@ resource "helm_release" "gooddata_cn" {
       aws_region       = var.aws_region
       organization_ids = local.org_ids
 
-      starrocks_fe_endpoint                = "kube-starrocks-fe-service.starrocks.svc.cluster.local"
+      starrocks_fe_endpoint                = "kube-starrocks-fe-service.${local.starrocks_namespace}.svc.cluster.local"
       starrocks_admin_password_secret_name = var.starrocks_admin_password_secret_name != "" ? var.starrocks_admin_password_secret_name : kubernetes_secret_v1.starrocks_admin_password[0].metadata[0].name
       starrocks_admin_password_secret_key  = var.starrocks_admin_password_secret_key != "" ? var.starrocks_admin_password_secret_key : "STARROCKS_ADMIN_PASSWORD"
 

--- a/modules/k8s-common/gooddata-orgs.tf
+++ b/modules/k8s-common/gooddata-orgs.tf
@@ -149,6 +149,10 @@ resource "kubectl_manifest" "gdcn_organization" {
     }, each.value.tls)
   })
 
+  # Block destroy until the controller clears its kopf finalizer, which it can only
+  # do while the gooddata-cn release is still running.
+  wait = true
+
   lifecycle {
     precondition {
       condition     = each.value.name != ""

--- a/modules/k8s-common/ingress.tf
+++ b/modules/k8s-common/ingress.tf
@@ -3,6 +3,10 @@
 ###
 
 locals {
+  # Shared between brotli-types and gzip-types below so the two encodings
+  # never silently drift out of sync.
+  ingress_compressible_mime_types = "application/vnd.gooddata.api+json application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
+
   ingress_values = {
     controller = merge(
       {
@@ -49,35 +53,32 @@ locals {
             large-client-header-buffers = "4 32k"
             client-header-buffer-size   = "32k"
             proxy-buffer-size           = "16k"
-            brotli-types                = "application/vnd.gooddata.api+json application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
+            brotli-types                = local.ingress_compressible_mime_types
             enable-brotli               = "true"
             use-gzip                    = "true"
-            gzip-types                  = "application/vnd.gooddata.api+json application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
+            gzip-types                  = local.ingress_compressible_mime_types
           },
           var.ingress_nginx_behind_l7 ? {
             use-forwarded-headers = "true"
           } : {}
         )
         addHeaders = {
-          Permission-Policy         = "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(), payment=()"
+          Permissions-Policy        = "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(), payment=()"
           Strict-Transport-Security = "max-age=31536000; includeSubDomains"
         }
       },
       var.cloud == "aws" ? {
         service = {
           annotations = merge(
+            local.aws_nlb_common_annotations,
             {
-              "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"                  = "tcp"
-              "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
-              "service.beta.kubernetes.io/aws-load-balancer-type"                              = "external"
-              "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
-              "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"           = "deregistration_delay.connection_termination.enabled=true,preserve_client_ip.enabled=true"
-              "service.beta.kubernetes.io/aws-load-balancer-scheme"                            = "internet-facing"
-              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-port"                  = "10254"
-              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-path"                  = "/healthz"
-              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"              = "HTTP"
-              "service.beta.kubernetes.io/aws-load-balancer-name"                              = "${var.deployment_name}-ingress"
-              "service.beta.kubernetes.io/aws-load-balancer-alpn-policy"                       = "HTTP2Preferred"
+              "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"        = "tcp"
+              "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes" = "deregistration_delay.connection_termination.enabled=true,preserve_client_ip.enabled=true"
+              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-port"        = "10254"
+              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-path"        = "/healthz"
+              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"    = "HTTP"
+              "service.beta.kubernetes.io/aws-load-balancer-name"                    = "${var.deployment_name}-ingress"
+              "service.beta.kubernetes.io/aws-load-balancer-alpn-policy"             = "HTTP2Preferred"
             }
           )
         }

--- a/modules/k8s-common/istio.tf
+++ b/modules/k8s-common/istio.tf
@@ -114,13 +114,9 @@ resource "helm_release" "istio_ingress_gateway" {
       ]
       annotations = merge(
         { "external-dns.alpha.kubernetes.io/hostname" = join(",", local.istio_gateway_hosts) },
-        var.cloud == "aws" ? {
-          "service.beta.kubernetes.io/aws-load-balancer-name"                              = local.aws_istio_nlb_load_balancer_name
-          "service.beta.kubernetes.io/aws-load-balancer-type"                              = "external"
-          "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
-          "service.beta.kubernetes.io/aws-load-balancer-scheme"                            = "internet-facing"
-          "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
-        } : {}
+        var.cloud == "aws" ? merge(local.aws_nlb_common_annotations, {
+          "service.beta.kubernetes.io/aws-load-balancer-name" = local.aws_istio_nlb_load_balancer_name
+        }) : {}
       )
     }
   })]

--- a/modules/k8s-common/locals.tf
+++ b/modules/k8s-common/locals.tf
@@ -5,7 +5,6 @@ locals {
   starrocks_namespace            = "starrocks"
   starrocks_service_account_name = "starrocks"
 
-  use_alb           = var.ingress_controller == "alb"
   use_ingress_nginx = var.ingress_controller == "ingress-nginx"
   use_lets_encrypt  = var.tls_mode == "letsencrypt"
   use_self_signed   = var.tls_mode == "selfsigned"
@@ -15,8 +14,26 @@ locals {
   cert_manager_cluster_issuer_name = local.use_self_signed ? "selfsigned" : "letsencrypt"
 
   # Reuse a single ingress class name throughout the module
-  resolved_ingress_class_name = var.ingress_controller == "alb" ? "alb" : (
-    var.ingress_controller == "istio_gateway" ? "" : "nginx"
-  )
+  resolved_ingress_class_name = lookup({ alb = "alb", istio_gateway = "" }, var.ingress_controller, "nginx")
+
+  # Shared across the ingress-nginx Service (ingress.tf) and the Istio ingress
+  # gateway Service (istio.tf) — the standard AWS NLB posture for both.
+  aws_nlb_common_annotations = {
+    "service.beta.kubernetes.io/aws-load-balancer-type"                              = "external"
+    "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
+    "service.beta.kubernetes.io/aws-load-balancer-scheme"                            = "internet-facing"
+    "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
+  }
+
+  # Shared istio-injection namespace label, applied when the Istio gateway is in use.
+  istio_injection_labels = local.use_istio_gateway ? {
+    "istio-injection" = "enabled"
+  } : null
+
+  # Shared cert-manager cluster-issuer annotation fragment, merged into ingress
+  # annotations wherever cert-manager manages the TLS certificate.
+  cert_manager_issuer_annotation = local.use_cert_manager ? {
+    "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
+  } : {}
 }
 

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -2,15 +2,17 @@ resource "kubernetes_namespace_v1" "observability" {
   count = var.enable_observability ? 1 : 0
 
   metadata {
-    name = "observability"
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = "observability"
+    labels = local.istio_injection_labels
   }
 }
 
 locals {
   # Observability sizing (obs_mem / obs_disk) lives in size-profiles.tf.
+
+  # Shared storage-class override, merged into the Prometheus/Tempo/Grafana
+  # persistence blocks below. Empty map leaves the PVC on the cluster default class.
+  gdcn_storage_class_override = var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
 
   # dotdc Kubernetes dashboards loaded into Grafana (see dashboards block below).
   grafana_kubernetes_dashboards = [
@@ -81,7 +83,7 @@ resource "helm_release" "kube_prometheus_stack" {
             volumeClaimTemplate = {
               spec = merge(
                 { resources = { requests = { storage = local.obs_disk.prometheus } } },
-                var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+                local.gdcn_storage_class_override
               )
             }
           }
@@ -262,9 +264,8 @@ resource "helm_release" "tempo" {
           }
           zipkin = { endpoint = "0.0.0.0:9411" }
         }
-        # Trace retention enforced by the block-storage compactor. The PVC (size
-        # set per tier in size-profiles.tf) still caps total size, so traces may
-        # be evicted before this period.
+        # Trace retention enforced by the block-storage compactor; it bounds
+        # object-storage usage.
         retention = var.tempo_retention_period
         # Per-tenant ingestion limits, sized by tier (see size-profiles.tf).
         # Strategy stays "local" (single-binary deployment, no global ring).
@@ -294,7 +295,7 @@ resource "helm_release" "tempo" {
       # size (obs_wal_disk), not retention-sized.
       persistence = merge(
         { enabled = true, size = var.obs_wal_disk },
-        var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+        local.gdcn_storage_class_override
       )
       resources = {
         requests = {
@@ -335,7 +336,7 @@ resource "helm_release" "grafana" {
       }
       persistence = merge(
         { enabled = true, size = "1Gi" },
-        var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+        local.gdcn_storage_class_override
       )
       resources = {
         requests = {
@@ -474,9 +475,7 @@ resource "helm_release" "grafana" {
           {
             "nginx.ingress.kubernetes.io/proxy-body-size" = "50m"
           },
-          local.use_cert_manager ? {
-            "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
-          } : {},
+          local.cert_manager_issuer_annotation,
           var.ingress_annotations_override
         )
         hosts = [var.observability_hostname]

--- a/modules/k8s-common/pulsar.tf
+++ b/modules/k8s-common/pulsar.tf
@@ -8,10 +8,8 @@ locals {
 
 resource "kubernetes_namespace_v1" "pulsar" {
   metadata {
-    name = local.pulsar_namespace
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = local.pulsar_namespace
+    labels = local.istio_injection_labels
   }
 }
 

--- a/modules/k8s-common/size-profiles.tf
+++ b/modules/k8s-common/size-profiles.tf
@@ -3,8 +3,8 @@
 # the same across AWS/Azure/local at a given tier, so they live here once and
 # the environment selects a tier by name via var.observability_size. Only the
 # observability stack (no per-tier Helm chart) is sized here; GoodData.CN,
-# Pulsar, and StarRocks sizing is selected by var.gdcn_size / var.pulsar_size /
-# var.starrocks_size_profile against templates/*-size-<tier>.yaml.tftpl and
+# Pulsar, and AI Lake sizing is selected by var.gdcn_size / var.pulsar_size /
+# var.ai_lake_size_profile against templates/*-size-<tier>.yaml.tftpl and
 # starrocks.tf, not this file.
 #
 # Observability CPU is intentionally left flat per-service (these components are

--- a/modules/k8s-common/starrocks.tf
+++ b/modules/k8s-common/starrocks.tf
@@ -6,10 +6,8 @@ resource "kubernetes_namespace_v1" "starrocks" {
   count = var.enable_ai_lake ? 1 : 0
 
   metadata {
-    name = local.starrocks_namespace
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = local.starrocks_namespace
+    labels = local.istio_injection_labels
   }
 }
 

--- a/modules/k8s-common/starrocks.tf
+++ b/modules/k8s-common/starrocks.tf
@@ -1,5 +1,6 @@
 ###
-# Deploy StarRocks in shared-data mode (FE + CN, S3 storage)
+# Deploy the StarRocks engine behind AI Lake, in shared-data mode (FE + CN,
+# S3 storage)
 ###
 
 resource "kubernetes_namespace_v1" "starrocks" {
@@ -125,7 +126,7 @@ resource "helm_release" "starrocks" {
       enable_observability      = var.enable_observability
       starrocks_fe_image_tag    = var.starrocks_fe_image_tag
       starrocks_cn_image_tag    = var.starrocks_cn_image_tag
-      fe_java_heap_mb           = local.starrocks_fe_heap_mb[var.starrocks_size_profile]
+      fe_java_heap_mb           = local.starrocks_fe_heap_mb[var.ai_lake_size_profile]
     }),
     var.cloud == "aws" ? templatefile("${path.module}/templates/starrocks-aws.yaml.tftpl", {
       starrocks_irsa_role_arn      = var.starrocks_irsa_role_arn
@@ -136,10 +137,10 @@ resource "helm_release" "starrocks" {
       aws_account_id               = var.aws_account_id
       starrocks_s3_bucket_id       = var.starrocks_s3_bucket_id
       s3_tables_bucket_name        = var.starrocks_s3_tables_bucket_name
-      fe_java_heap_mb              = local.starrocks_fe_heap_mb[var.starrocks_size_profile]
+      fe_java_heap_mb              = local.starrocks_fe_heap_mb[var.ai_lake_size_profile]
       node_workload_label          = "starrocks"
     }) : null,
-    templatefile("${path.module}/templates/starrocks-size-${var.starrocks_size_profile}.yaml.tftpl", {}),
+    templatefile("${path.module}/templates/starrocks-size-${var.ai_lake_size_profile}.yaml.tftpl", {}),
   ])
 
   wait          = true

--- a/modules/k8s-common/templates/gdcn-ai-lake.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-ai-lake.yaml.tftpl
@@ -19,7 +19,7 @@ aiLake:
     extraConfig:
       override.toml: |
 %{ for org_id in organization_ids ~}
-        # StarRocks cluster for ${org_id} org
+        # StarRocks compute cluster for ${org_id} org
         [compute_clusters.${org_id}]
         name = "starrocks-${org_id}"
         organization_id = "${org_id}"

--- a/modules/k8s-common/templates/gdcn-base.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-base.yaml.tftpl
@@ -81,14 +81,19 @@ tools:
 # Disable telemetry
 telemetry:
   enabled: false
-%{ if storage_class != "" }
+%{ if fast_storage_class != "" }
 
-# Pin PVC storage class per size profile (set from Terraform). Covers the
-# always-present chart PVCs (etcd, redis-ha) and qdrant when AI features are on.
-# etcd takes the fast class, since Quiver blocks on its fsync latency.
+# etcd takes the fast class, since Quiver blocks on its fsync latency. Rendered
+# on its own so fast_storage_class still applies when gdcn_storage_class is
+# unset (it falls back to gdcn_storage_class when empty).
 customEtcd:
   persistence:
     storageClassName: ${fast_storage_class}
+%{ endif ~}
+%{ if storage_class != "" }
+
+# Pin the remaining chart PVCs per size profile (set from Terraform): redis-ha
+# is always present, qdrant only when AI features are on.
 redis-ha:
   persistentVolume:
     storageClass: ${storage_class}

--- a/modules/k8s-common/templates/gdcn-base.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-base.yaml.tftpl
@@ -85,9 +85,10 @@ telemetry:
 
 # Pin PVC storage class per size profile (set from Terraform). Covers the
 # always-present chart PVCs (etcd, redis-ha) and qdrant when AI features are on.
+# etcd takes the fast class, since Quiver blocks on its fsync latency.
 customEtcd:
   persistence:
-    storageClassName: ${storage_class}
+    storageClassName: ${fast_storage_class}
 redis-ha:
   persistentVolume:
     storageClass: ${storage_class}

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -24,9 +24,6 @@ platform_limits:
 # cache nodes, preventing hiccups during high load and releases.
 deployDedicatedPolicyNodes: true
 
-# Deploy dedicated Quiver datasource-filesystem nodes to offload datasource reads.
-deployQuiverDatasourceFs: true
-
 # Long-poll AFM execution results instead of client polling.
 enableAfmLongPoll: true
 
@@ -86,13 +83,13 @@ automation:
       value: "false"
 calcique:
   jvmOptions: -Xmx1024M -XX:MaxMetaspaceSize=320M -XX:MaxDirectMemorySize=512M
-  replicaCount: 4
+  replicaCount: 2
   resources:
     limits:
-      cpu: 1500m
+      cpu: 3000m
       memory: 2800Mi
     requests:
-      cpu: 300m
+      cpu: 1500m
       memory: 2800Mi
 customEtcd:
   enabled: true
@@ -104,7 +101,7 @@ customEtcd:
       cpu: 2000m
       memory: 4096Mi
   persistence:
-    size: 512Gi
+    size: 30Gi
 dashboards:
   resources:
     limits:
@@ -257,8 +254,8 @@ quiver:
     # cache serves every DoGet + absorbs DoPut/S3 writes on cache miss; 2 pods
     # saturated the put pipeline under load.
     cache: 8
-    # xtab is I/O-bound (Flight reads from cache); scaled to 18 pods plus widened
-    # worker pools (extraEnvVarsXtab) to keep the cross-tab queue clear under load.
+    # xtab is I/O-bound (Flight reads from cache); 8 pods with capped worker
+    # pools (extraEnvVarsXtab) keep the queue clear without swamping the cache.
     xtab: 8
   resources:
     cache:
@@ -281,9 +278,8 @@ quiver:
         memory: 7680Mi
       requests:
         cpu: 2000m
-        # Steady-state RSS runs well above the old request, letting the scheduler
-        # overcommit nodes and evict xtab pods under load. Request is set above
-        # observed peak (still below the limit).
+        # Set above observed peak RSS (still under the limit) so the scheduler
+        # can't overcommit nodes and evict xtab pods under load.
         memory: 5120Mi
     ml:
       limits:
@@ -361,10 +357,10 @@ redis-ha:
       maxmemory: 7300m
     resources:
       limits:
-        cpu: 1500m
+        cpu: 2000m
         memory: 9125Mi
       requests:
-        cpu: 700m
+        cpu: 1500m
         memory: 9125Mi
   sentinel:
     resources:

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -3,7 +3,7 @@
 # High-traffic multi-tenant sizing: more hot-path replicas + CPU/memory than
 # prod-small, dedicated Quiver policy nodes, larger result cache.
 #
-# StarRocks (AI Lake) is sized separately via var.starrocks_size_profile
+# AI Lake is sized separately via var.ai_lake_size_profile
 # (dev/prod-small/prod-xl); it is not derived from this profile.
 
 replicaCount: 2

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -100,6 +100,9 @@ customEtcd:
     limits:
       cpu: 2000m
       memory: 4096Mi
+  # Down from 512Gi, which was far more than etcd can use. A StatefulSet
+  # volumeClaimTemplate cannot shrink in place, so an existing prod-large
+  # install rejects this on upgrade until its etcd PVCs are recreated.
   persistence:
     size: 30Gi
 dashboards:

--- a/modules/k8s-common/templates/gdcn-size-prod-small.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-small.yaml.tftpl
@@ -77,6 +77,10 @@ customEtcd:
     limits:
       cpu: 600m
       memory: 1024Mi
+  # Above the chart's 8Gi default, so the fast storage class can deliver its
+  # full provisioned IOPS (see the per-cloud class definitions).
+  persistence:
+    size: 20Gi
 dashboards:
   resources:
     limits:

--- a/modules/k8s-common/templates/gdcn-size-prod-small.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-small.yaml.tftpl
@@ -77,8 +77,8 @@ customEtcd:
     limits:
       cpu: 600m
       memory: 1024Mi
-  # Above the chart's 8Gi default, so the fast storage class can deliver its
-  # full provisioned IOPS (see the per-cloud class definitions).
+  # Above the chart's 8Gi default: etcd holds Quiver's flight catalog, and a full
+  # volume wedges writes.
   persistence:
     size: 20Gi
 dashboards:

--- a/modules/k8s-common/templates/pulsar-istio.tftpl
+++ b/modules/k8s-common/templates/pulsar-istio.tftpl
@@ -1,20 +1,10 @@
 # Istio sidecar tuning for Pulsar.
 
-zookeeper:
+%{ for component in ["zookeeper", "bookkeeper", "broker"] ~}
+${component}:
   annotations:
     sidecar.istio.io/proxyCPU: "100m"
     sidecar.istio.io/proxyCPULimit: "1"
     sidecar.istio.io/proxyMemory: "256Mi"
     sidecar.istio.io/proxyMemoryLimit: "1536Mi"
-bookkeeper:
-  annotations:
-    sidecar.istio.io/proxyCPU: "100m"
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: "256Mi"
-    sidecar.istio.io/proxyMemoryLimit: "1536Mi"
-broker:
-  annotations:
-    sidecar.istio.io/proxyCPU: "100m"
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: "256Mi"
-    sidecar.istio.io/proxyMemoryLimit: "1536Mi"
+%{ endfor ~}

--- a/modules/k8s-common/templates/starrocks-aws.yaml.tftpl
+++ b/modules/k8s-common/templates/starrocks-aws.yaml.tftpl
@@ -9,8 +9,8 @@ operator:
 
 starrocks:
   starrocksFESpec:
-    # Bind FE pods to the dedicated StarRocks managed node group
-    # (matches taint workload=starrocks:NoSchedule applied in aws/eks.tf).
+    # Bind FE pods to the dedicated StarRocks node pool
+    # (matches taint workload=starrocks:NoSchedule set in aws/karpenter.tf).
     nodeSelector:
       workload: ${node_workload_label}
     tolerations:
@@ -176,8 +176,8 @@ starrocks:
             memory: 256Mi
 
   starrocksCnSpec:
-    # Bind CN pods to the dedicated StarRocks managed node group
-    # (matches taint workload=starrocks:NoSchedule applied in aws/eks.tf).
+    # Bind CN pods to the dedicated StarRocks node pool
+    # (matches taint workload=starrocks:NoSchedule set in aws/karpenter.tf).
     nodeSelector:
       workload: ${node_workload_label}
     tolerations:

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -1,3 +1,9 @@
+# Required only when enable_ai_lake is true (AI Lake is AWS-only); null otherwise.
+variable "ai_lake_size_profile" {
+  type    = string
+  default = null
+}
+
 variable "auth_hostname" { type = string }
 
 variable "aws_region" {
@@ -66,6 +72,12 @@ variable "enable_ai_lake" {
   default     = false
 }
 
+variable "fast_storage_class" {
+  description = "StorageClass for latency-sensitive GoodData.CN PVCs (etcd today). Falls back to gdcn_storage_class when empty."
+  type        = string
+  default     = ""
+}
+
 variable "s3_tables_bucket_arn" {
   description = "ARN of the AWS S3 Tables bucket used by AI Lake."
   type        = string
@@ -85,7 +97,7 @@ variable "glue_etl_role_arn" {
 }
 
 variable "starrocks_s3_tables_iam_user_arn" {
-  description = "ARN of the IAM user used by StarRocks to access AWS S3 Tables."
+  description = "ARN of the IAM user used by AI Lake to access AWS S3 Tables."
   type        = string
   default     = ""
 }
@@ -287,12 +299,6 @@ variable "pulsar_size" {
     condition     = contains(local.workload_size_tiers, var.pulsar_size)
     error_message = "pulsar_size must be one of: dev, prod-small, prod-large (fold prod-xl to prod-large in the env's size-profiles.tf)."
   }
-}
-
-# Required only when enable_ai_lake is true (StarRocks is AWS-only); null otherwise.
-variable "starrocks_size_profile" {
-  type    = string
-  default = null
 }
 
 variable "starrocks_cn_image_tag" {

--- a/modules/k8s-local/seaweedfs.tf
+++ b/modules/k8s-local/seaweedfs.tf
@@ -88,9 +88,9 @@ resource "helm_release" "seaweedfs" {
         }
 
         # Single PVC backs every bucket (Quiver cache, exports, datasource FS,
-        # and now Loki/Tempo object storage), so it must be sized for all of
-        # them. local-path is thin-provisioned, so the request is a ceiling, not
-        # a preallocation.
+        # Loki/Tempo object storage), so it must be sized for all of them.
+        # local-path is thin-provisioned, so the request is a ceiling, not a
+        # preallocation.
         data = {
           type         = "persistentVolumeClaim"
           size         = var.seaweedfs_storage_size

--- a/scripts/configure-kubectl.sh
+++ b/scripts/configure-kubectl.sh
@@ -14,11 +14,7 @@ case "${CURRENT_DIR}" in
   aws)
     require_command aws "AWS CLI not found; install it to configure kubectl."
     require_command kubectl "kubectl not found; install it to interact with Kubernetes."
-    load_tf_outputs
-    if ! has_tf_outputs; then
-      echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
-      exit 1
-    fi
+    require_tf_outputs
 
     EKS_CLUSTER_NAME=$(tf_output_value "eks_cluster_name")
     AWS_REGION=$(tf_output_value "aws_region")
@@ -41,11 +37,7 @@ case "${CURRENT_DIR}" in
   azure)
     require_command az "Azure CLI not found; install it to configure kubectl."
     require_command kubectl "kubectl not found; install it to interact with Kubernetes."
-    load_tf_outputs
-    if ! has_tf_outputs; then
-      echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
-      exit 1
-    fi
+    require_tf_outputs
 
     AKS_CLUSTER_NAME=$(tf_output_value "aks_cluster_name")
     RESOURCE_GROUP=$(tf_output_value "azure_resource_group_name")
@@ -73,11 +65,7 @@ case "${CURRENT_DIR}" in
   local)
     require_command k3d "k3d CLI not found; install it to configure kubectl for local clusters."
     require_command kubectl "kubectl not found; install it to interact with Kubernetes."
-    load_tf_outputs
-    if ! has_tf_outputs; then
-      echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
-      exit 1
-    fi
+    require_tf_outputs
 
     K3D_CLUSTER_NAME=$(tf_output_value "k3d_cluster_name")
     KUBECONFIG_CONTEXT=$(tf_output_value "kubeconfig_context")

--- a/scripts/create-grafana-user.sh
+++ b/scripts/create-grafana-user.sh
@@ -14,22 +14,15 @@ GRAFANA_CURL_CONNECT_ARGS=()
 try_load_grafana_admin_credentials_from_secret() {
   local namespace="observability"
   local secret_name="${1:-grafana}"
-  local admin_user_b64 admin_password_b64 admin_user admin_password
+  local admin_user admin_password
 
   command_exists kubectl || return 1
   command_exists base64 || return 1
 
   kubectl get secret -n "${namespace}" "${secret_name}" >/dev/null 2>&1 || return 1
 
-  admin_user_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.admin-user}' 2>/dev/null || true)
-  admin_password_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.admin-password}' 2>/dev/null || true)
-
-  if [[ -z "${admin_user_b64}" || -z "${admin_password_b64}" ]]; then
-    return 1
-  fi
-
-  admin_user=$(printf '%s' "${admin_user_b64}" | base64 -d 2>/dev/null || true)
-  admin_password=$(printf '%s' "${admin_password_b64}" | base64 -d 2>/dev/null || true)
+  admin_user=$(load_k8s_secret_field "${namespace}" "${secret_name}" "admin-user") || return 1
+  admin_password=$(load_k8s_secret_field "${namespace}" "${secret_name}" "admin-password") || return 1
 
   if [[ -z "${admin_user}" || -z "${admin_password}" ]]; then
     return 1
@@ -42,13 +35,7 @@ try_load_grafana_admin_credentials_from_secret() {
 }
 
 configure_grafana_connect_args() {
-  GRAFANA_CURL_CONNECT_ARGS=()
-  if is_inside_container && [[ "${OBSERVABILITY_HOSTNAME}" == "localhost" || "${OBSERVABILITY_HOSTNAME}" == *.localhost ]]; then
-    if command_exists getent && getent hosts host.docker.internal >/dev/null 2>&1; then
-      echo "Container detected, routing via host.docker.internal."
-      GRAFANA_CURL_CONNECT_ARGS=(--connect-to "${OBSERVABILITY_HOSTNAME}:443:host.docker.internal:443")
-    fi
-  fi
+  docker_internal_connect_to_args "${OBSERVABILITY_HOSTNAME}" GRAFANA_CURL_CONNECT_ARGS
 }
 
 resolve_grafana_admin_credentials() {
@@ -79,15 +66,9 @@ resolve_grafana_admin_credentials() {
 }
 
 curl_grafana_json() {
-  local response status body
-  response=$(curl --silent --show-error --write-out "\n%{http_code}" \
+  curl_with_status \
     "${CURL_TLS_ARGS[@]}" "${GRAFANA_CURL_CONNECT_ARGS[@]}" \
-    -u "${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}" "$@")
-  status=${response##*$'\n'}
-  body=${response%$'\n'*}
-
-  printf '%s\n%s\n' "${body}" "${status}"
-  [[ "${status}" =~ ^2 ]]
+    -u "${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}" "$@"
 }
 
 ###

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -11,36 +11,22 @@ CURL_TLS_ARGS=()
 CURL_CONNECT_ARGS=()
 
 curl_json() {
-  local response status body
-  response=$(curl --silent --show-error --write-out "\n%{http_code}" "${CURL_TLS_ARGS[@]}" "${CURL_CONNECT_ARGS[@]}" "$@")
-  status=${response##*$'\n'}
-  body=${response%$'\n'*}
-
-  printf '%s\n%s\n' "${body}" "${status}"
-
-  [[ "${status}" =~ ^2 ]]
+  curl_with_status "${CURL_TLS_ARGS[@]}" "${CURL_CONNECT_ARGS[@]}" "$@"
 }
 
 try_load_admin_credentials_from_secret() {
   local namespace="${1}"
   local org_id="${2}"
   local secret_name="gdcn-org-admin-${org_id}"
-  local admin_user_b64 admin_password_b64 admin_user admin_password
+  local admin_user admin_password
 
   command_exists kubectl || return 1
   command_exists base64 || return 1
 
   kubectl get secret -n "${namespace}" "${secret_name}" >/dev/null 2>&1 || return 1
 
-  admin_user_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.adminUser}' 2>/dev/null || true)
-  admin_password_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.adminPassword}' 2>/dev/null || true)
-
-  if [[ -z "${admin_user_b64}" || -z "${admin_password_b64}" ]]; then
-    return 1
-  fi
-
-  admin_user=$(printf '%s' "${admin_user_b64}" | base64 -d 2>/dev/null || true)
-  admin_password=$(printf '%s' "${admin_password_b64}" | base64 -d 2>/dev/null || true)
+  admin_user=$(load_k8s_secret_field "${namespace}" "${secret_name}" "adminUser") || return 1
+  admin_password=$(load_k8s_secret_field "${namespace}" "${secret_name}" "adminPassword") || return 1
 
   if [[ -z "${admin_user}" || -z "${admin_password}" ]]; then
     return 1
@@ -512,16 +498,7 @@ if [[ -z "${GDCN_ORG_HOSTNAME}" ]]; then
   GDCN_ORG_HOSTNAME=$(prompt_required ">> Organization domain (e.g. example.com): " "Organization domain is required")
 fi
 
-# If we're running inside a devcontainer, "localhost" refers to the container.
-# For local k3d (Docker-outside-of-Docker), the ingress port is on the Docker host.
-# Important: keep the URL hostname as-is so Ingress host routing works, but
-# connect to host.docker.internal underneath.
-if is_inside_container && [[ "${GDCN_ORG_HOSTNAME}" == "localhost" || "${GDCN_ORG_HOSTNAME}" == *.localhost ]]; then
-  if command_exists getent && getent hosts host.docker.internal >/dev/null 2>&1; then
-    echo "Container detected, routing via host.docker.internal."
-    CURL_CONNECT_ARGS=(--connect-to "${GDCN_ORG_HOSTNAME}:443:host.docker.internal:443")
-  fi
-fi
+docker_internal_connect_to_args "${GDCN_ORG_HOSTNAME}" CURL_CONNECT_ARGS
 
 # Admin credentials
 # - Prefer environment overrides if set (useful for CI)

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -42,6 +42,23 @@ is_inside_container() {
   return 1
 }
 
+docker_internal_connect_to_args() {
+  # If we're running inside a devcontainer, "localhost" refers to the container.
+  # For local k3d (Docker-outside-of-Docker), the ingress port is on the Docker host.
+  # Important: keep the URL hostname as-is so Ingress host routing works, but
+  # connect to host.docker.internal underneath.
+  local hostname="$1"
+  local -n out_array="$2"
+  out_array=()
+
+  if is_inside_container && [[ "${hostname}" == "localhost" || "${hostname}" == *.localhost ]]; then
+    if command_exists getent && getent hosts host.docker.internal >/dev/null 2>&1; then
+      echo "Container detected, routing via host.docker.internal."
+      out_array=(--connect-to "${hostname}:443:host.docker.internal:443")
+    fi
+  fi
+}
+
 require_command() {
   local binary="$1"
   local message="${2:-}"
@@ -87,6 +104,14 @@ has_tf_outputs() {
     jq -e 'length > 0' <<<"${TF_OUTPUT_JSON}" >/dev/null 2>&1
   else
     [[ "${TF_OUTPUT_JSON}" != "{}" ]]
+  fi
+}
+
+require_tf_outputs() {
+  load_tf_outputs
+  if ! has_tf_outputs; then
+    echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
+    exit 1
   fi
 }
 
@@ -246,4 +271,28 @@ prompt_choice() {
 
 urlencode() {
   jq -rn --arg v "${1}" '$v|@uri'
+}
+
+# Runs curl with the given args, prints "<body>\n<http_status>\n" on stdout,
+# and returns success only if the status code is 2xx.
+curl_with_status() {
+  local response status body
+  response=$(curl --silent --show-error --write-out "\n%{http_code}" "$@")
+  status=${response##*$'\n'}
+  body=${response%$'\n'*}
+
+  printf '%s\n%s\n' "${body}" "${status}"
+
+  [[ "${status}" =~ ^2 ]]
+}
+
+# Fetches a single field from a Kubernetes Secret's .data and base64-decodes it.
+# Prints the decoded value on stdout; returns 1 if the field is missing/empty
+# or cannot be decoded.
+load_k8s_secret_field() {
+  local namespace="$1" secret="$2" key="$3"
+  local raw
+  raw=$(kubectl get secret -n "${namespace}" "${secret}" -o jsonpath="{.data.${key}}" 2>/dev/null || true)
+  [[ -n "${raw}" ]] || return 1
+  printf '%s' "${raw}" | base64 -d 2>/dev/null
 }


### PR DESCRIPTION
Deduplicates copy-pasted config and applies the production fixes found in review. Azure DNS work stays in #203. Stacked on #217.

**Refactors** — shared locals for the S3 IRSA policies, ECR registry base, OIDC condition key, node IAM policies, NLB annotations, Istio labels, and the brotli/gzip MIME list. Shell helpers extracted to `scripts/lib/common.sh`.

**Hardening**
- `gp3`/`gp3-perf` StorageClasses set `encrypted = true`
- Profile-derived backup retention for RDS and Azure PostgreSQL (14d prod / 7d dev)
- Drop the AKS kubelet identity's resource-group-wide Contributor grant
- Fix the misspelled `Permission-Policy` header
- Loki/Tempo retention to 720h, now they are object-storage backed

Applying replaces the `gp3` StorageClasses (parameters are immutable), so new PVCs are briefly Pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AWS and Azure database backup retention, deletion protection, and optional geo-redundant backups.
  * Added AI Lake sizing, dedicated compute, fast storage, and node capacity options.
  * Improved Kubernetes scheduling, storage encryption, networking, and autoscaling configuration.
* **Bug Fixes**
  * Improved infrastructure cleanup and safer cluster removal.
  * Corrected regional container registry URLs and access permissions.
  * Strengthened ingress, certificate, service, and credential handling.
* **Documentation**
  * Updated setup instructions, configuration examples, naming, retention guidance, and AI feature defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->