### PR TITLE
refactor: extract shared locals and shell helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ Requirements:
 1. Choose your provider and `cd` into its directory: `cd aws`, `cd azure`, or `cd local`
 
 1. Authenticate to your cloud provider's CLI:
-    - For AWS: `aws login` / `aws sso login` (or otherwise configure your AWS credentials)
+    - For AWS: authenticate the profile named by `aws_profile_name` in
+      `settings.tfvars`, since Terraform uses it regardless of your default
+      profile. For an IAM Identity Center (SSO) profile that is
+      `aws sso login --profile <aws_profile_name>`; for access keys it is
+      `aws configure --profile <aws_profile_name>`.
     - For Azure: `az login`
     - Azure note: Terraform's Kubernetes authentication uses `kubelogin` with your Azure CLI session.
 

--- a/aws/ecr-pullthrough.tf
+++ b/aws/ecr-pullthrough.tf
@@ -7,28 +7,21 @@ data "aws_caller_identity" "current" {}
 
 # If image caching is enabled, construct the registry URL. Otherwise, return the upstream one.
 locals {
+  ecr_registry_base = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com"
+
   upstream_registry_dockerio = "registry-1.docker.io"
-  registry_dockerio = var.enable_image_cache ? format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.id,
-    aws_ecr_pull_through_cache_rule.dockerio[0].ecr_repository_prefix
+  registry_dockerio = var.enable_image_cache ? (
+    "${local.ecr_registry_base}/${aws_ecr_pull_through_cache_rule.dockerio[0].ecr_repository_prefix}"
   ) : local.upstream_registry_dockerio
 
   upstream_registry_quayio = "quay.io"
-  registry_quayio = var.enable_image_cache ? format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.id,
-    aws_ecr_pull_through_cache_rule.quayio[0].ecr_repository_prefix
+  registry_quayio = var.enable_image_cache ? (
+    "${local.ecr_registry_base}/${aws_ecr_pull_through_cache_rule.quayio[0].ecr_repository_prefix}"
   ) : local.upstream_registry_quayio
 
   upstream_registry_k8sio = "registry.k8s.io"
-  registry_k8sio = var.enable_image_cache ? format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.id,
-    aws_ecr_pull_through_cache_rule.k8sio[0].ecr_repository_prefix
+  registry_k8sio = var.enable_image_cache ? (
+    "${local.ecr_registry_base}/${aws_ecr_pull_through_cache_rule.k8sio[0].ecr_repository_prefix}"
   ) : local.upstream_registry_k8sio
 }
 

--- a/aws/lakeformation.tf
+++ b/aws/lakeformation.tf
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "s3tables_data_access" {
     ]
 
     resources = [
-      "arn:aws:s3tables:${var.aws_region}:${data.aws_caller_identity.current.account_id}:bucket/*"
+      local.s3tables_bucket_wildcard_arn
     ]
   }
 
@@ -115,11 +115,11 @@ data "aws_iam_policy_document" "s3tables_data_access" {
     ]
 
     resources = [
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog/s3tablescatalog",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog/s3tablescatalog/*",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:database/s3tablescatalog/*",
-      "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/s3tablescatalog/*",
+      "${local.glue_arn_prefix}:catalog",
+      "${local.glue_arn_prefix}:catalog/s3tablescatalog",
+      "${local.glue_arn_prefix}:catalog/s3tablescatalog/*",
+      "${local.glue_arn_prefix}:database/s3tablescatalog/*",
+      "${local.glue_arn_prefix}:table/s3tablescatalog/*",
     ]
   }
 }
@@ -147,7 +147,7 @@ resource "aws_iam_role_policy" "s3tables_lakeformation" {
 resource "aws_lakeformation_resource" "s3tables" {
   count = var.enable_ai_lake ? 1 : 0
 
-  arn                    = "arn:aws:s3tables:${var.aws_region}:${data.aws_caller_identity.current.account_id}:bucket/*"
+  arn                    = local.s3tables_bucket_wildcard_arn
   role_arn               = aws_iam_role.s3tables_lakeformation[0].arn
   with_federation        = true
   with_privileged_access = true
@@ -395,13 +395,7 @@ data "aws_iam_policy_document" "s3tables_ailake_access" {
       "glue:GetTable",
       "glue:GetTables",
     ]
-    resources = [
-      "${local.glue_arn_prefix}:catalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}",
-      "${local.glue_arn_prefix}:database/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*",
-      "${local.glue_arn_prefix}:table/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*/*",
-    ]
+    resources = local.glue_s3tables_catalog_arns
   }
 
   statement {
@@ -507,13 +501,7 @@ data "aws_iam_policy_document" "glue_etl_job_access" {
       "glue:UpdateDatabase",
       "glue:GetCatalogImportStatus",
     ]
-    resources = [
-      "${local.glue_arn_prefix}:catalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog",
-      "${local.glue_arn_prefix}:catalog/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}",
-      "${local.glue_arn_prefix}:database/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*",
-      "${local.glue_arn_prefix}:table/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*/*",
-    ]
+    resources = local.glue_s3tables_catalog_arns
   }
 
   statement {

--- a/aws/providers.tf
+++ b/aws/providers.tf
@@ -54,6 +54,10 @@ locals {
   # Shared Kubernetes auth settings (aws eks get-token)
   kube_host = module.eks.cluster_endpoint
   kube_ca   = base64decode(module.eks.cluster_certificate_authority_data)
+
+  # OIDC condition key for IRSA trust policies (irsa.tf), e.g.
+  # "oidc.eks.<region>.amazonaws.com/id/<id>:sub"
+  eks_oidc_condition_key = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
   eks_exec = {
     api_version = "client.authentication.k8s.io/v1"
     command     = "aws"

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -76,8 +76,67 @@ locals {
   gdcn_s3_object_arns = formatlist("%s/*", local.gdcn_s3_bucket_arns)
 
   # Shared ARN fragments for StarRocks Glue/S3 Tables policies
-  glue_arn_prefix     = "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}"
-  s3tables_catalog_id = "${data.aws_caller_identity.current.account_id}:s3tablescatalog"
+  glue_arn_prefix              = "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}"
+  s3tables_catalog_id          = "${data.aws_caller_identity.current.account_id}:s3tablescatalog"
+  s3tables_bucket_wildcard_arn = "arn:aws:s3tables:${var.aws_region}:${data.aws_caller_identity.current.account_id}:bucket/*"
+
+  # Shared Glue catalog ARN list for the StarRocks S3 Tables federated catalog
+  # (catalog / catalog/s3tablescatalog / per-bucket catalog / database / table).
+  # Guarded by enable_ai_lake since it indexes into the count-gated table bucket.
+  glue_s3tables_catalog_arns = var.enable_ai_lake ? [
+    "${local.glue_arn_prefix}:catalog",
+    "${local.glue_arn_prefix}:catalog/s3tablescatalog",
+    "${local.glue_arn_prefix}:catalog/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}",
+    "${local.glue_arn_prefix}:database/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*",
+    "${local.glue_arn_prefix}:table/s3tablescatalog/${aws_s3tables_table_bucket.starrocks_tables[0].name}/*/*",
+  ] : []
+
+  # Shared two-statement (list+location, then object read/write/multipart) IAM
+  # policy JSON shape used by the gdcn, observability and starrocks S3 access
+  # policies below; only the per-consumer Resource lists differ. The starrocks
+  # ARNs are guarded by enable_ai_lake since the bucket is count-gated.
+  s3_rw_policy_json = {
+    for name, cfg in {
+      gdcn = {
+        bucket_arns = local.gdcn_s3_bucket_arns
+        object_arns = local.gdcn_s3_object_arns
+      }
+      observability = {
+        bucket_arns = local.obs_s3_bucket_arns
+        object_arns = local.obs_s3_object_arns
+      }
+      starrocks = {
+        bucket_arns = var.enable_ai_lake ? [aws_s3_bucket.starrocks[0].arn] : []
+        object_arns = var.enable_ai_lake ? ["${aws_s3_bucket.starrocks[0].arn}/*"] : []
+      }
+      } : name => jsonencode({
+        Version = "2012-10-17",
+        Statement = [
+          {
+            Sid    = "AllowBucketListingAndLocation",
+            Effect = "Allow",
+            Action = [
+              "s3:ListBucket",
+              "s3:GetBucketLocation",
+              "s3:ListBucketMultipartUploads"
+            ],
+            Resource = cfg.bucket_arns
+          },
+          {
+            Sid    = "AllowObjectReadWriteAndMultipart",
+            Effect = "Allow",
+            Action = [
+              "s3:GetObject",
+              "s3:PutObject",
+              "s3:DeleteObject",
+              "s3:AbortMultipartUpload",
+              "s3:ListMultipartUploadParts"
+            ],
+            Resource = cfg.object_arns
+          }
+        ]
+    })
+  }
 }
 
 ###
@@ -129,33 +188,7 @@ resource "aws_iam_policy" "starrocks_s3_access" {
   name        = "${var.deployment_name}-StarRocksS3Access"
   description = "Allow StarRocks workloads to use S3 bucket for shared-data storage."
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowBucketListingAndLocation",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:ListBucketMultipartUploads"
-        ],
-        Resource = [aws_s3_bucket.starrocks[0].arn]
-      },
-      {
-        Sid    = "AllowObjectReadWriteAndMultipart",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListMultipartUploadParts"
-        ],
-        Resource = ["${aws_s3_bucket.starrocks[0].arn}/*"]
-      }
-    ]
-  })
+  policy = local.s3_rw_policy_json["starrocks"]
 }
 
 ###
@@ -279,33 +312,7 @@ resource "aws_iam_policy" "gdcn_s3_access" {
   name        = "${var.deployment_name}-GoodDataCNS3Access"
   description = "Allow GoodData.CN workloads to use S3 buckets for quiver cache, datasource FS, and exports."
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowBucketListingAndLocation",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:ListBucketMultipartUploads"
-        ],
-        Resource = local.gdcn_s3_bucket_arns
-      },
-      {
-        Sid    = "AllowObjectReadWriteAndMultipart",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListMultipartUploadParts"
-        ],
-        Resource = local.gdcn_s3_object_arns
-      }
-    ]
-  })
+  policy = local.s3_rw_policy_json["gdcn"]
 }
 
 ###
@@ -367,31 +374,5 @@ resource "aws_iam_policy" "observability_s3_access" {
   name        = "${var.deployment_name}-ObservabilityS3Access"
   description = "Allow Loki and Tempo to use S3 buckets for object storage."
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowBucketListingAndLocation",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:ListBucketMultipartUploads"
-        ],
-        Resource = local.obs_s3_bucket_arns
-      },
-      {
-        Sid    = "AllowObjectReadWriteAndMultipart",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListMultipartUploadParts"
-        ],
-        Resource = local.obs_s3_object_arns
-      }
-    ]
-  })
+  policy = local.s3_rw_policy_json["observability"]
 }

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -33,8 +33,9 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 #       replicaCount: 3
 # EOT
 
-# Uncomment to deploy and enable GoodData generative AI services
-# enable_ai_features = true
+# Uncomment to disable AI features: the GenAI service, semantic search, chat,
+# metadata sync and Qdrant.
+# enable_ai_features = false
 
 # Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -30,8 +30,9 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 #       replicaCount: 3
 # EOT
 
-# Uncomment to deploy and enable GoodData generative AI services
-# enable_ai_features = true
+# Uncomment to disable AI features: the GenAI service, semantic search, chat,
+# metadata sync and Qdrant.
+# enable_ai_features = false
 
 # Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
@@ -76,8 +77,8 @@ dns_provider = "self-managed"
 
 # Option 1 — NGINX Ingress Controller (ingress-nginx) + Let's Encrypt certificates (letsencrypt)
 ingress_controller = "ingress-nginx"
-tls_mode          = "letsencrypt"
-letsencrypt_email = "me@example.com"
+tls_mode           = "letsencrypt"
+letsencrypt_email  = "me@example.com"
 
 # Uncomment when ingress-nginx sits behind another L7 proxy/load balancer.
 # ingress_nginx_behind_l7 = true

--- a/local/settings.tfvars.example
+++ b/local/settings.tfvars.example
@@ -29,8 +29,9 @@ gdcn_license_key = "key/asdf==" # provided by GoodData
 #       replicaCount: 3
 # EOT
 
-# Uncomment to deploy and enable GoodData generative AI services
-# enable_ai_features = true
+# Uncomment to disable AI features: the GenAI service, semantic search, chat,
+# metadata sync and Qdrant.
+# enable_ai_features = false
 
 # Uncomment to enable experimental features (unofficially unsupported and unstable; talk to GoodData to learn more)
 # enable_experimental_features = true
@@ -45,8 +46,8 @@ size_profile = "dev"
 ###
 
 # Option 1 — NGINX Ingress Controller (ingress-nginx) + cert-manager self-signed certificates
-ingress_controller      = "ingress-nginx"
-tls_mode                = "selfsigned"
+ingress_controller = "ingress-nginx"
+tls_mode           = "selfsigned"
 
 # Option 2 — Istio Gateway + cert-manager self-signed certificates
 # ingress_controller = "istio_gateway"

--- a/modules/k8s-common/cert-manager.tf
+++ b/modules/k8s-common/cert-manager.tf
@@ -73,7 +73,7 @@ resource "kubectl_manifest" "letsencrypt_cluster_issuer" {
               local.cert_manager_http01_ingress_class == "nginx" ? {
                 ingressTemplate = {
                   metadata = {
-                    annotations = { "nginx.ingress.kubernetes.io/enable-validate-ingress" = "false" }
+                    annotations = local.cert_manager_http01_ingress_annotations
                   }
                 }
               } : {}

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -10,15 +10,9 @@ locals {
     {
       "nginx.ingress.kubernetes.io/proxy-body-size" = "200m"
     },
-    local.use_cert_manager ? {
-      "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
-    } : {}
+    local.cert_manager_issuer_annotation
   ) : {}
-  dex_annotation_defaults = local.use_ingress_nginx ? (
-    local.use_cert_manager ? {
-      "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
-    } : {}
-  ) : {}
+  dex_annotation_defaults = local.use_ingress_nginx ? local.cert_manager_issuer_annotation : {}
   ingress_annotations     = merge(local.ingress_annotation_defaults, var.ingress_annotations_override)
   dex_ingress_annotations = merge(local.dex_annotation_defaults, var.dex_ingress_annotations_override)
   dex_tls_enabled         = local.use_cert_manager
@@ -43,10 +37,8 @@ resource "kubectl_manifest" "peerauth_gdcn_strict" {
 
 resource "kubernetes_namespace_v1" "gdcn" {
   metadata {
-    name = var.gdcn_namespace
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = var.gdcn_namespace
+    labels = local.istio_injection_labels
   }
 }
 
@@ -168,7 +160,7 @@ resource "helm_release" "gooddata_cn" {
       aws_region       = var.aws_region
       organization_ids = local.org_ids
 
-      starrocks_fe_endpoint                = "kube-starrocks-fe-service.starrocks.svc.cluster.local"
+      starrocks_fe_endpoint                = "kube-starrocks-fe-service.${local.starrocks_namespace}.svc.cluster.local"
       starrocks_admin_password_secret_name = var.starrocks_admin_password_secret_name != "" ? var.starrocks_admin_password_secret_name : kubernetes_secret_v1.starrocks_admin_password[0].metadata[0].name
       starrocks_admin_password_secret_key  = var.starrocks_admin_password_secret_key != "" ? var.starrocks_admin_password_secret_key : "STARROCKS_ADMIN_PASSWORD"
 

--- a/modules/k8s-common/ingress.tf
+++ b/modules/k8s-common/ingress.tf
@@ -3,6 +3,10 @@
 ###
 
 locals {
+  # Shared between brotli-types and gzip-types below so the two encodings
+  # never silently drift out of sync.
+  ingress_compressible_mime_types = "application/vnd.gooddata.api+json application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
+
   ingress_values = {
     controller = merge(
       {
@@ -49,35 +53,32 @@ locals {
             large-client-header-buffers = "4 32k"
             client-header-buffer-size   = "32k"
             proxy-buffer-size           = "16k"
-            brotli-types                = "application/vnd.gooddata.api+json application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
+            brotli-types                = local.ingress_compressible_mime_types
             enable-brotli               = "true"
             use-gzip                    = "true"
-            gzip-types                  = "application/vnd.gooddata.api+json application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
+            gzip-types                  = local.ingress_compressible_mime_types
           },
           var.ingress_nginx_behind_l7 ? {
             use-forwarded-headers = "true"
           } : {}
         )
         addHeaders = {
-          Permission-Policy         = "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(), payment=()"
+          Permissions-Policy        = "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(), payment=()"
           Strict-Transport-Security = "max-age=31536000; includeSubDomains"
         }
       },
       var.cloud == "aws" ? {
         service = {
           annotations = merge(
+            local.aws_nlb_common_annotations,
             {
-              "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"                  = "tcp"
-              "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
-              "service.beta.kubernetes.io/aws-load-balancer-type"                              = "external"
-              "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
-              "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes"           = "deregistration_delay.connection_termination.enabled=true,preserve_client_ip.enabled=true"
-              "service.beta.kubernetes.io/aws-load-balancer-scheme"                            = "internet-facing"
-              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-port"                  = "10254"
-              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-path"                  = "/healthz"
-              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"              = "HTTP"
-              "service.beta.kubernetes.io/aws-load-balancer-name"                              = "${var.deployment_name}-ingress"
-              "service.beta.kubernetes.io/aws-load-balancer-alpn-policy"                       = "HTTP2Preferred"
+              "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"        = "tcp"
+              "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes" = "deregistration_delay.connection_termination.enabled=true,preserve_client_ip.enabled=true"
+              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-port"        = "10254"
+              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-path"        = "/healthz"
+              "service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol"    = "HTTP"
+              "service.beta.kubernetes.io/aws-load-balancer-name"                    = "${var.deployment_name}-ingress"
+              "service.beta.kubernetes.io/aws-load-balancer-alpn-policy"             = "HTTP2Preferred"
             }
           )
         }

--- a/modules/k8s-common/istio.tf
+++ b/modules/k8s-common/istio.tf
@@ -114,13 +114,9 @@ resource "helm_release" "istio_ingress_gateway" {
       ]
       annotations = merge(
         { "external-dns.alpha.kubernetes.io/hostname" = join(",", local.istio_gateway_hosts) },
-        var.cloud == "aws" ? {
-          "service.beta.kubernetes.io/aws-load-balancer-name"                              = local.aws_istio_nlb_load_balancer_name
-          "service.beta.kubernetes.io/aws-load-balancer-type"                              = "external"
-          "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
-          "service.beta.kubernetes.io/aws-load-balancer-scheme"                            = "internet-facing"
-          "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
-        } : {}
+        var.cloud == "aws" ? merge(local.aws_nlb_common_annotations, {
+          "service.beta.kubernetes.io/aws-load-balancer-name" = local.aws_istio_nlb_load_balancer_name
+        }) : {}
       )
     }
   })]

--- a/modules/k8s-common/locals.tf
+++ b/modules/k8s-common/locals.tf
@@ -5,7 +5,6 @@ locals {
   starrocks_namespace            = "starrocks"
   starrocks_service_account_name = "starrocks"
 
-  use_alb           = var.ingress_controller == "alb"
   use_ingress_nginx = var.ingress_controller == "ingress-nginx"
   use_lets_encrypt  = var.tls_mode == "letsencrypt"
   use_self_signed   = var.tls_mode == "selfsigned"
@@ -15,8 +14,26 @@ locals {
   cert_manager_cluster_issuer_name = local.use_self_signed ? "selfsigned" : "letsencrypt"
 
   # Reuse a single ingress class name throughout the module
-  resolved_ingress_class_name = var.ingress_controller == "alb" ? "alb" : (
-    var.ingress_controller == "istio_gateway" ? "" : "nginx"
-  )
+  resolved_ingress_class_name = lookup({ alb = "alb", istio_gateway = "" }, var.ingress_controller, "nginx")
+
+  # Shared across the ingress-nginx Service (ingress.tf) and the Istio ingress
+  # gateway Service (istio.tf) — the standard AWS NLB posture for both.
+  aws_nlb_common_annotations = {
+    "service.beta.kubernetes.io/aws-load-balancer-type"                              = "external"
+    "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"                   = "ip"
+    "service.beta.kubernetes.io/aws-load-balancer-scheme"                            = "internet-facing"
+    "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled" = "true"
+  }
+
+  # Shared istio-injection namespace label, applied when the Istio gateway is in use.
+  istio_injection_labels = local.use_istio_gateway ? {
+    "istio-injection" = "enabled"
+  } : null
+
+  # Shared cert-manager cluster-issuer annotation fragment, merged into ingress
+  # annotations wherever cert-manager manages the TLS certificate.
+  cert_manager_issuer_annotation = local.use_cert_manager ? {
+    "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
+  } : {}
 }
 

--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -2,15 +2,17 @@ resource "kubernetes_namespace_v1" "observability" {
   count = var.enable_observability ? 1 : 0
 
   metadata {
-    name = "observability"
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = "observability"
+    labels = local.istio_injection_labels
   }
 }
 
 locals {
   # Observability sizing (obs_mem / obs_disk) lives in size-profiles.tf.
+
+  # Shared storage-class override, merged into the Prometheus/Tempo/Grafana
+  # persistence blocks below. Empty map leaves the PVC on the cluster default class.
+  gdcn_storage_class_override = var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
 
   # Loki's backend name: the configured object store, else local filesystem.
   loki_object_store = var.loki_objstore != null ? var.loki_objstore.object_store : "filesystem"
@@ -84,7 +86,7 @@ resource "helm_release" "kube_prometheus_stack" {
             volumeClaimTemplate = {
               spec = merge(
                 { resources = { requests = { storage = local.obs_disk.prometheus } } },
-                var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+                local.gdcn_storage_class_override
               )
             }
           }
@@ -265,9 +267,8 @@ resource "helm_release" "tempo" {
           }
           zipkin = { endpoint = "0.0.0.0:9411" }
         }
-        # Trace retention enforced by the block-storage compactor. The PVC (size
-        # set per tier in size-profiles.tf) still caps total size, so traces may
-        # be evicted before this period.
+        # Trace retention enforced by the block-storage compactor; it bounds
+        # object-storage usage.
         retention = var.tempo_retention_period
         # Per-tenant ingestion limits, sized by tier (see size-profiles.tf).
         # Strategy stays "local" (single-binary deployment, no global ring).
@@ -297,7 +298,7 @@ resource "helm_release" "tempo" {
       # size (obs_wal_disk), not retention-sized.
       persistence = merge(
         { enabled = true, size = var.obs_wal_disk },
-        var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+        local.gdcn_storage_class_override
       )
       resources = {
         requests = {
@@ -338,7 +339,7 @@ resource "helm_release" "grafana" {
       }
       persistence = merge(
         { enabled = true, size = "1Gi" },
-        var.gdcn_storage_class != "" ? { storageClassName = var.gdcn_storage_class } : {}
+        local.gdcn_storage_class_override
       )
       resources = {
         requests = {
@@ -477,9 +478,7 @@ resource "helm_release" "grafana" {
           {
             "nginx.ingress.kubernetes.io/proxy-body-size" = "50m"
           },
-          local.use_cert_manager ? {
-            "cert-manager.io/cluster-issuer" = local.cert_manager_cluster_issuer_name
-          } : {},
+          local.cert_manager_issuer_annotation,
           var.ingress_annotations_override
         )
         hosts = [var.observability_hostname]

--- a/modules/k8s-common/pulsar.tf
+++ b/modules/k8s-common/pulsar.tf
@@ -8,10 +8,8 @@ locals {
 
 resource "kubernetes_namespace_v1" "pulsar" {
   metadata {
-    name = local.pulsar_namespace
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = local.pulsar_namespace
+    labels = local.istio_injection_labels
   }
 }
 

--- a/modules/k8s-common/templates/pulsar-istio.tftpl
+++ b/modules/k8s-common/templates/pulsar-istio.tftpl
@@ -1,20 +1,10 @@
 # Istio sidecar tuning for Pulsar.
 
-zookeeper:
+%{ for component in ["zookeeper", "bookkeeper", "broker"] ~}
+${component}:
   annotations:
     sidecar.istio.io/proxyCPU: "100m"
     sidecar.istio.io/proxyCPULimit: "1"
     sidecar.istio.io/proxyMemory: "256Mi"
     sidecar.istio.io/proxyMemoryLimit: "1536Mi"
-bookkeeper:
-  annotations:
-    sidecar.istio.io/proxyCPU: "100m"
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: "256Mi"
-    sidecar.istio.io/proxyMemoryLimit: "1536Mi"
-broker:
-  annotations:
-    sidecar.istio.io/proxyCPU: "100m"
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: "256Mi"
-    sidecar.istio.io/proxyMemoryLimit: "1536Mi"
+%{ endfor ~}

--- a/scripts/configure-kubectl.sh
+++ b/scripts/configure-kubectl.sh
@@ -14,11 +14,7 @@ case "${CURRENT_DIR}" in
   aws)
     require_command aws "AWS CLI not found; install it to configure kubectl."
     require_command kubectl "kubectl not found; install it to interact with Kubernetes."
-    load_tf_outputs
-    if ! has_tf_outputs; then
-      echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
-      exit 1
-    fi
+    require_tf_outputs
 
     EKS_CLUSTER_NAME=$(tf_output_value "eks_cluster_name")
     AWS_REGION=$(tf_output_value "aws_region")
@@ -41,11 +37,7 @@ case "${CURRENT_DIR}" in
   azure)
     require_command az "Azure CLI not found; install it to configure kubectl."
     require_command kubectl "kubectl not found; install it to interact with Kubernetes."
-    load_tf_outputs
-    if ! has_tf_outputs; then
-      echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
-      exit 1
-    fi
+    require_tf_outputs
 
     AKS_CLUSTER_NAME=$(tf_output_value "aks_cluster_name")
     RESOURCE_GROUP=$(tf_output_value "azure_resource_group_name")
@@ -73,11 +65,7 @@ case "${CURRENT_DIR}" in
   local)
     require_command k3d "k3d CLI not found; install it to configure kubectl for local clusters."
     require_command kubectl "kubectl not found; install it to interact with Kubernetes."
-    load_tf_outputs
-    if ! has_tf_outputs; then
-      echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
-      exit 1
-    fi
+    require_tf_outputs
 
     K3D_CLUSTER_NAME=$(tf_output_value "k3d_cluster_name")
     KUBECONFIG_CONTEXT=$(tf_output_value "kubeconfig_context")

--- a/scripts/create-grafana-user.sh
+++ b/scripts/create-grafana-user.sh
@@ -14,22 +14,15 @@ GRAFANA_CURL_CONNECT_ARGS=()
 try_load_grafana_admin_credentials_from_secret() {
   local namespace="observability"
   local secret_name="${1:-grafana}"
-  local admin_user_b64 admin_password_b64 admin_user admin_password
+  local admin_user admin_password
 
   command_exists kubectl || return 1
   command_exists base64 || return 1
 
   kubectl get secret -n "${namespace}" "${secret_name}" >/dev/null 2>&1 || return 1
 
-  admin_user_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.admin-user}' 2>/dev/null || true)
-  admin_password_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.admin-password}' 2>/dev/null || true)
-
-  if [[ -z "${admin_user_b64}" || -z "${admin_password_b64}" ]]; then
-    return 1
-  fi
-
-  admin_user=$(printf '%s' "${admin_user_b64}" | base64 -d 2>/dev/null || true)
-  admin_password=$(printf '%s' "${admin_password_b64}" | base64 -d 2>/dev/null || true)
+  admin_user=$(load_k8s_secret_field "${namespace}" "${secret_name}" "admin-user") || return 1
+  admin_password=$(load_k8s_secret_field "${namespace}" "${secret_name}" "admin-password") || return 1
 
   if [[ -z "${admin_user}" || -z "${admin_password}" ]]; then
     return 1
@@ -42,13 +35,8 @@ try_load_grafana_admin_credentials_from_secret() {
 }
 
 configure_grafana_connect_args() {
-  GRAFANA_CURL_CONNECT_ARGS=()
-  if is_inside_container && [[ "${OBSERVABILITY_HOSTNAME}" == "localhost" || "${OBSERVABILITY_HOSTNAME}" == *.localhost ]]; then
-    if command_exists getent && getent hosts host.docker.internal >/dev/null 2>&1; then
-      echo "Container detected, routing via host.docker.internal."
-      GRAFANA_CURL_CONNECT_ARGS=(--connect-to "${OBSERVABILITY_HOSTNAME}:443:host.docker.internal:443")
-    fi
-  fi
+  docker_internal_connect_to_args "${OBSERVABILITY_HOSTNAME}"
+  GRAFANA_CURL_CONNECT_ARGS=(${DOCKER_CONNECT_TO_ARGS[@]+"${DOCKER_CONNECT_TO_ARGS[@]}"})
 }
 
 resolve_grafana_admin_credentials() {
@@ -79,15 +67,9 @@ resolve_grafana_admin_credentials() {
 }
 
 curl_grafana_json() {
-  local response status body
-  response=$(curl --silent --show-error --write-out "\n%{http_code}" \
+  curl_with_status \
     "${CURL_TLS_ARGS[@]}" "${GRAFANA_CURL_CONNECT_ARGS[@]}" \
-    -u "${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}" "$@")
-  status=${response##*$'\n'}
-  body=${response%$'\n'*}
-
-  printf '%s\n%s\n' "${body}" "${status}"
-  [[ "${status}" =~ ^2 ]]
+    -u "${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}" "$@"
 }
 
 ###

--- a/scripts/create-user.sh
+++ b/scripts/create-user.sh
@@ -11,36 +11,22 @@ CURL_TLS_ARGS=()
 CURL_CONNECT_ARGS=()
 
 curl_json() {
-  local response status body
-  response=$(curl --silent --show-error --write-out "\n%{http_code}" "${CURL_TLS_ARGS[@]}" "${CURL_CONNECT_ARGS[@]}" "$@")
-  status=${response##*$'\n'}
-  body=${response%$'\n'*}
-
-  printf '%s\n%s\n' "${body}" "${status}"
-
-  [[ "${status}" =~ ^2 ]]
+  curl_with_status "${CURL_TLS_ARGS[@]}" "${CURL_CONNECT_ARGS[@]}" "$@"
 }
 
 try_load_admin_credentials_from_secret() {
   local namespace="${1}"
   local org_id="${2}"
   local secret_name="gdcn-org-admin-${org_id}"
-  local admin_user_b64 admin_password_b64 admin_user admin_password
+  local admin_user admin_password
 
   command_exists kubectl || return 1
   command_exists base64 || return 1
 
   kubectl get secret -n "${namespace}" "${secret_name}" >/dev/null 2>&1 || return 1
 
-  admin_user_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.adminUser}' 2>/dev/null || true)
-  admin_password_b64=$(kubectl get secret -n "${namespace}" "${secret_name}" -o jsonpath='{.data.adminPassword}' 2>/dev/null || true)
-
-  if [[ -z "${admin_user_b64}" || -z "${admin_password_b64}" ]]; then
-    return 1
-  fi
-
-  admin_user=$(printf '%s' "${admin_user_b64}" | base64 -d 2>/dev/null || true)
-  admin_password=$(printf '%s' "${admin_password_b64}" | base64 -d 2>/dev/null || true)
+  admin_user=$(load_k8s_secret_field "${namespace}" "${secret_name}" "adminUser") || return 1
+  admin_password=$(load_k8s_secret_field "${namespace}" "${secret_name}" "adminPassword") || return 1
 
   if [[ -z "${admin_user}" || -z "${admin_password}" ]]; then
     return 1
@@ -512,17 +498,9 @@ if [[ -z "${GDCN_ORG_HOSTNAME}" ]]; then
   GDCN_ORG_HOSTNAME=$(prompt_required ">> Organization domain (e.g. example.com): " "Organization domain is required")
 fi
 
-# If we're running inside a devcontainer, "localhost" refers to the container.
-# For local k3d (Docker-outside-of-Docker), the ingress port is on the Docker host.
-# Important: keep the URL hostname as-is so Ingress host routing works, but
-# connect to host.docker.internal underneath.
-if is_inside_container && [[ "${GDCN_ORG_HOSTNAME}" == "localhost" || "${GDCN_ORG_HOSTNAME}" == *.localhost ]]; then
-  if command_exists getent && getent hosts host.docker.internal >/dev/null 2>&1; then
-    echo "Container detected, routing via host.docker.internal."
-    CURL_CONNECT_ARGS=(--connect-to "${GDCN_ORG_HOSTNAME}:443:host.docker.internal:443")
-  fi
-fi
+docker_internal_connect_to_args "${GDCN_ORG_HOSTNAME}"
 
+CURL_CONNECT_ARGS=(${DOCKER_CONNECT_TO_ARGS[@]+"${DOCKER_CONNECT_TO_ARGS[@]}"})
 # Admin credentials
 # - Prefer environment overrides if set (useful for CI)
 # - Otherwise, try to read from a Terraform-managed Secret

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -42,6 +42,24 @@ is_inside_container() {
   return 1
 }
 
+# Sets DOCKER_CONNECT_TO_ARGS. A global rather than a nameref: `local -n` needs
+# bash 4.3, and these scripts otherwise run on 4.0.
+docker_internal_connect_to_args() {
+  # If we're running inside a devcontainer, "localhost" refers to the container.
+  # For local k3d (Docker-outside-of-Docker), the ingress port is on the Docker host.
+  # Important: keep the URL hostname as-is so Ingress host routing works, but
+  # connect to host.docker.internal underneath.
+  local hostname="$1"
+  DOCKER_CONNECT_TO_ARGS=()
+
+  if is_inside_container && [[ "${hostname}" == "localhost" || "${hostname}" == *.localhost ]]; then
+    if command_exists getent && getent hosts host.docker.internal >/dev/null 2>&1; then
+      echo "Container detected, routing via host.docker.internal."
+      DOCKER_CONNECT_TO_ARGS=(--connect-to "${hostname}:443:host.docker.internal:443")
+    fi
+  fi
+}
+
 require_command() {
   local binary="$1"
   local message="${2:-}"
@@ -87,6 +105,14 @@ has_tf_outputs() {
     jq -e 'length > 0' <<<"${TF_OUTPUT_JSON}" >/dev/null 2>&1
   else
     [[ "${TF_OUTPUT_JSON}" != "{}" ]]
+  fi
+}
+
+require_tf_outputs() {
+  load_tf_outputs
+  if ! has_tf_outputs; then
+    echo ">> ERROR: Terraform outputs not available. Run 'terraform apply' first." >&2
+    exit 1
   fi
 }
 
@@ -246,4 +272,28 @@ prompt_choice() {
 
 urlencode() {
   jq -rn --arg v "${1}" '$v|@uri'
+}
+
+# Runs curl with the given args, prints "<body>\n<http_status>\n" on stdout,
+# and returns success only if the status code is 2xx.
+curl_with_status() {
+  local response status body
+  response=$(curl --silent --show-error --write-out "\n%{http_code}" "$@")
+  status=${response##*$'\n'}
+  body=${response%$'\n'*}
+
+  printf '%s\n%s\n' "${body}" "${status}"
+
+  [[ "${status}" =~ ^2 ]]
+}
+
+# Fetches a single field from a Kubernetes Secret's .data and base64-decodes it.
+# Prints the decoded value on stdout; returns 1 if the field is missing/empty
+# or cannot be decoded.
+load_k8s_secret_field() {
+  local namespace="$1" secret="$2" key="$3"
+  local raw
+  raw=$(kubectl get secret -n "${namespace}" "${secret}" -o jsonpath="{.data.${key}}" 2>/dev/null || true)
+  [[ -n "${raw}" ]] || return 1
+  printf '%s' "${raw}" | base64 -d 2>/dev/null
 }


### PR DESCRIPTION
**Stack 1/7** — split out of #230. Base: `master`.

No functional change. Deduplicates copy-pasted config and corrects comments that had drifted.

- `modules/k8s-common`: shared locals for the NLB annotations, istio injection labels, cert-manager issuer annotation, the brotli/gzip MIME list and the starrocks namespace.
- `aws`: shared locals for the S3 IRSA policy documents, the ECR registry base, the account id and the EKS OIDC condition key.
- `scripts`: common helpers moved into `scripts/lib/common.sh`.
- Comment and example-file corrections, including the commented-out Loki/Tempo retention samples.

**How to review:** this one has a mechanical criterion — `terraform plan` against an existing workspace should report **no changes**. I could not run that here (no credentials/cluster), so it is worth one plan before approving.

`terraform fmt -check` clean; `validate` passes in aws, azure and local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated AWS authentication guidance with profile-based configuration and separate SSO or access-key instructions.

- **Configuration**
  - Example settings now disable generative AI services by default.
  - Improved configurable namespace, storage, TLS, ingress, and observability settings.

- **Infrastructure**
  - Improved container registry caching across AWS, Quay, Docker Hub, and Kubernetes registries.
  - Standardized cloud access, ingress, certificate, and service configuration.

- **Bug Fixes**
  - Corrected the `Permissions-Policy` response header.
  - Improved Kubernetes secret, Terraform output, networking, and HTTP error handling in setup scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->