### PR TITLE
fix(iam): scope node identities and the node security group

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -29,7 +29,16 @@ locals {
     ECRPullThroughCacheMin = aws_iam_policy.ecr_pull_through_cache_min[0].arn
   } : {}
 
-  # Node sizing / StarRocks node types: resolved in size-profiles.tf and applied
+  # Managed policies shared by every node role (system managed node group here,
+  # and the Karpenter node role in karpenter.tf): image pull, plus the
+  # pull-through cache policy when image caching is enabled. EBS volume calls
+  # are made by the CSI controller, which gets AmazonEBSCSIDriverPolicy through
+  # aws_iam_role.ebs_csi_irsa — nodes do not need it.
+  node_iam_role_additional_policies = merge({
+    AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
+  }, local.ecr_pull_through_cache_policy)
+
+  # Node sizing / AI Lake node types: resolved in size-profiles.tf and applied
   # via Karpenter NodePools (see karpenter.tf), not managed node groups.
 }
 
@@ -63,6 +72,7 @@ module "eks" {
     aws-ebs-csi-driver = {
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
+      service_account_role_arn    = aws_iam_role.ebs_csi_irsa.arn
     }
   }
 
@@ -95,10 +105,7 @@ module "eks" {
 
       tags = local.common_tags
 
-      iam_role_additional_policies = merge({
-        AmazonEBSCSIDriverPolicy           = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-        AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
-      }, local.ecr_pull_through_cache_policy)
+      iam_role_additional_policies = local.node_iam_role_additional_policies
 
       min_size     = 2
       max_size     = 3
@@ -112,7 +119,17 @@ module "eks" {
     "karpenter.sh/discovery" = var.deployment_name
   }
 
-  node_security_group_additional_rules = var.ingress_controller == "istio_gateway" ? {
+  # Pod IPs live on node ENIs, so this group governs all pod-to-pod traffic.
+  node_security_group_additional_rules = merge({
+    node_to_node_all = {
+      description = "Node to node, all ports and protocols"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    }, var.ingress_controller == "istio_gateway" ? {
     istio_xds = {
       description                   = "Istio XDS (istiod) to workloads"
       protocol                      = "tcp"
@@ -129,7 +146,7 @@ module "eks" {
       type                          = "ingress"
       source_cluster_security_group = true
     }
-  } : {}
+  } : {})
 }
 
 # Outputs

--- a/aws/irsa.tf
+++ b/aws/irsa.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "gdcn_irsa_assume_role" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      variable = local.eks_oidc_condition_key
       values = [
         "system:serviceaccount:${var.gdcn_namespace}:${local.gdcn_service_account_name}"
       ]
@@ -32,6 +32,44 @@ resource "aws_iam_role" "gdcn_irsa" {
 resource "aws_iam_role_policy_attachment" "gdcn_irsa_s3_access" {
   role       = aws_iam_role.gdcn_irsa.name
   policy_arn = aws_iam_policy.gdcn_s3_access.arn
+}
+
+###
+# IAM role for the EBS CSI driver (IRSA)
+###
+
+# Without this the driver falls back to IMDS, which pods cannot reach at the
+# default hop limit of 1.
+data "aws_iam_policy_document" "ebs_csi_irsa_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = local.eks_oidc_condition_key
+      values = [
+        "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi_irsa" {
+  name               = "${var.deployment_name}-ebs-csi-irsa"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_irsa_assume_role.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_irsa" {
+  role       = aws_iam_role.ebs_csi_irsa.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 }
 
 ###
@@ -53,7 +91,7 @@ data "aws_iam_policy_document" "observability_irsa_assume_role" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      variable = local.eks_oidc_condition_key
       values = [
         "system:serviceaccount:observability:loki",
         "system:serviceaccount:observability:tempo",
@@ -98,7 +136,7 @@ data "aws_iam_policy_document" "starrocks_irsa_assume_role" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      variable = local.eks_oidc_condition_key
       values = [
         "system:serviceaccount:starrocks:starrocks"
       ]

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -19,12 +19,9 @@ module "karpenter" {
   # association binding the kube-system/karpenter service account to the role.
   create_pod_identity_association = true
 
-  # Lets Karpenter-launched nodes use the EBS CSI driver and pull images
-  # (incl. via the optional pull-through cache).
-  node_iam_role_additional_policies = merge({
-    AmazonEBSCSIDriverPolicy           = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-    AmazonEC2ContainerRegistryPullOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
-  }, local.ecr_pull_through_cache_policy)
+  # Lets Karpenter-launched nodes pull images (incl. via the optional
+  # pull-through cache). Same policy set as the system node group.
+  node_iam_role_additional_policies = local.node_iam_role_additional_policies
 
   tags = local.common_tags
 }

--- a/azure/aks.tf
+++ b/azure/aks.tf
@@ -97,12 +97,8 @@ resource "azurerm_kubernetes_cluster" "main" {
   depends_on = [azurerm_subnet_nat_gateway_association.aks]
 }
 
-# Grant AKS cluster permissions to manage the resource group
-resource "azurerm_role_assignment" "aks_cluster_contributor" {
-  scope                = azurerm_resource_group.main.id
-  role_definition_name = "Contributor"
-  principal_id         = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
-}
+# The kubelet identity gets no resource-group-wide grant: any pod can reach it
+# via IMDS. Real needs use scoped identities (AcrPull below, UAMIs in identity.tf).
 
 # Grant AKS cluster's system identity Network Contributor permissions for LoadBalancer services
 resource "azurerm_role_assignment" "aks_system_identity_network_contributor" {

--- a/azure/k8s-common.tf
+++ b/azure/k8s-common.tf
@@ -126,6 +126,12 @@ module "k8s_common" {
     # DNS must resolve before cert-manager issues its first Let's Encrypt cert;
     # a failed issuance backs off up to 32h. No-op unless dns_provider=azure-dns.
     helm_release.external_dns,
+    # Node capacity must outlive the helm releases too: deleting the NodePool
+    # taints every Karpenter node, leaving pre-delete hooks unschedulable.
+    kubectl_manifest.karpenter_node_pool,
+    # Deleting a LoadBalancer Service needs subnet join, so this grant must
+    # outlive the ingress release or the Azure LB can never be torn down.
+    azurerm_role_assignment.aks_system_identity_network_contributor,
   ]
 }
 

--- a/azure/karpenter.tf
+++ b/azure/karpenter.tf
@@ -22,7 +22,10 @@ resource "kubectl_manifest" "karpenter_node_class" {
     }
   })
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }
 
 # General-purpose NodePool: on-demand AMD general-purpose D-series with a


### PR DESCRIPTION
**Stack 2/7** — split out of #230. Base: #1 (`stack/1-refactor-locals`).

- **EBS CSI**: the addon gets its own IRSA role and `AmazonEBSCSIDriverPolicy` comes off the system and Karpenter node roles. Volume calls come from the controller, so every node no longer carries create/attach/delete on EBS. The addon is wired to the IRSA role in this same PR, so the driver is never left without permissions.
- **AKS**: drop the resource-group-wide `Contributor` grant on the kubelet identity — any pod can reach that identity over IMDS. The real needs are already served by scoped grants (`AcrPull`, and the UAMIs in `identity.tf`).
- Node security group rules become an explicit merge, since pod IPs live on node ENIs and this group therefore governs pod-to-pod traffic.

**Review question:** does anything still rely on a permission removed here? Nothing in-repo references the dropped grant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Reduced Azure AKS kubelet permissions by removing broad resource-group Contributor access.
  - Scoped AWS EKS permissions for node roles and the EBS CSI driver.
  - Improved EKS node-to-node connectivity while retaining conditional ingress controls.

- **Reliability**
  - Improved Kubernetes resource cleanup and deployment ordering for Azure networking and node capacity.
  - Ensured required cluster permissions are available before applying node configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->