### PR TITLE
fix(db): make lifecycle and backup defaults actually apply

### DIFF
--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -91,8 +91,13 @@ module "rds_postgresql" {
   # Connectivity & lifecycle
   publicly_accessible = false
   storage_encrypted   = true
-  skip_final_snapshot = var.rds_skip_final_snapshot
-  deletion_protection = var.rds_deletion_protection
+  skip_final_snapshot = local.rds_skip_final_snapshot
+  deletion_protection = local.rds_deletion_protection
+
+  # PITR window well past the RDS ~1-day fallback; fixed off-hours windows.
+  backup_retention_period = local.rds_backup_retention_period
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "Sun:04:30-Sun:05:30"
 
   tags = local.common_tags
 }

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -158,8 +158,16 @@ gdcn_orgs = [
 # eks_endpoint_public_access_cidrs = ["x.x.x.x/32"]
 # eks_endpoint_private_access      = false
 
-# Uncomment to override RDS defaults. apply_immediately reboots the DB to apply
-# changes (e.g. an instance-class change) instead of waiting for maintenance.
-# rds_apply_immediately   = false
-# rds_deletion_protection = false
-# rds_skip_final_snapshot = true
+# Uncomment to override RDS defaults. Left unset these follow size_profile:
+# prod keeps deletion protection and takes a final snapshot on destroy, dev does
+# neither. apply_immediately applies pending changes during terraform apply
+# rather than at the next maintenance window; those that need a restart cause
+# downtime when they land.
+#
+# With deletion protection on, `terraform destroy` fails until you first apply
+# with rds_deletion_protection = false. Set rds_skip_final_snapshot = false only
+# when you want that snapshot kept after the instance is gone.
+# rds_apply_immediately       = false
+# rds_backup_retention_period = 14
+# rds_deletion_protection     = true
+# rds_skip_final_snapshot     = false

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -98,6 +98,11 @@ locals {
   # Resolved size_profile values (profile default, overridable via var.*).
   rds_instance_class    = coalesce(var.rds_instance_class, local.profile.rds.instance_class)
   rds_allocated_storage = coalesce(var.rds_allocated_storage, local.profile.rds.allocated_storage)
+  # Lifecycle and backups follow the profile unless the matching var.* is set.
+  rds_is_prod                 = startswith(var.size_profile, "prod")
+  rds_deletion_protection     = var.rds_deletion_protection != null ? var.rds_deletion_protection : local.rds_is_prod
+  rds_skip_final_snapshot     = var.rds_skip_final_snapshot != null ? var.rds_skip_final_snapshot : !local.rds_is_prod
+  rds_backup_retention_period = coalesce(var.rds_backup_retention_period, local.rds_is_prod ? 14 : 7)
   # System node group instance type (not user-configurable). Workload nodes are
   # sized by Karpenter (instance-category + CPU bounds below).
   system_node_type = local.profile.system_node_type

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -434,10 +434,26 @@ variable "rds_apply_immediately" {
   default     = false
 }
 
+variable "rds_backup_retention_period" {
+  description = "Days of automated RDS backups / point-in-time recovery. If null, chosen by size_profile (14 for prod, 7 for dev)."
+  type        = number
+  default     = null
+  validation {
+    # coalesce keeps floor() off a null value: Terraform before 1.12
+    # evaluates both sides of ||.
+    condition = (
+      coalesce(var.rds_backup_retention_period, 0) == floor(coalesce(var.rds_backup_retention_period, 0))
+      && coalesce(var.rds_backup_retention_period, 0) >= 0
+      && coalesce(var.rds_backup_retention_period, 0) <= 35
+    )
+    error_message = "rds_backup_retention_period must be a whole number of days between 0 and 35."
+  }
+}
+
 variable "rds_deletion_protection" {
-  description = "Enable deletion protection on the RDS instance."
+  description = "Enable deletion protection on the RDS instance. If null, chosen by size_profile (on for prod, off for dev)."
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "rds_instance_class" {
@@ -447,9 +463,9 @@ variable "rds_instance_class" {
 }
 
 variable "rds_skip_final_snapshot" {
-  description = "Skip taking a final snapshot when destroying the RDS instance."
+  description = "Skip taking a final snapshot when destroying the RDS instance. If null, chosen by size_profile (final snapshot for prod, skipped for dev)."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "route53_zone_id" {

--- a/azure/postgresql.tf
+++ b/azure/postgresql.tf
@@ -49,8 +49,11 @@ resource "azurerm_postgresql_flexible_server" "main" {
   # Disable public network access when using VNet integration
   public_network_access_enabled = false
 
-  backup_retention_days = 7
-  auto_grow_enabled     = true
+  backup_retention_days = local.postgresql_backup_retention_days
+  # Backups in the paired region. Opt-in, not profile-derived: Azure only accepts
+  # this at create time, so changing it recreates the server (destroying the DB).
+  geo_redundant_backup_enabled = var.postgresql_geo_redundant_backup
+  auto_grow_enabled            = true
 
   maintenance_window {
     day_of_week  = 0

--- a/azure/settings.tfvars.example
+++ b/azure/settings.tfvars.example
@@ -142,3 +142,6 @@ gdcn_orgs = [
 # Uncomment to override AKS defaults
 # aks_version                         = "1.36"
 # aks_api_server_authorized_ip_ranges = ["x.x.x.x/32"]
+
+# Uncomment to replicate backups to the Azure paired region.
+# postgresql_geo_redundant_backup = true

--- a/azure/size-profiles.tf
+++ b/azure/size-profiles.tf
@@ -77,9 +77,12 @@ locals {
   profile = local.size_profiles[var.size_profile]
 
   # Resolved managed values (profile default, overridable via var.*).
-  postgresql_sku_name   = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
-  postgresql_storage_mb = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
-  aks_min_nodes         = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
+  postgresql_sku_name = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
+  # Prod keeps 14 days of point-in-time recovery, dev the 7-day minimum.
+  postgresql_is_prod               = startswith(var.size_profile, "prod")
+  postgresql_backup_retention_days = coalesce(var.postgresql_backup_retention_days, local.postgresql_is_prod ? 14 : 7)
+  postgresql_storage_mb            = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
+  aks_min_nodes                    = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
   # System pool VM size (not user-configurable). Workload nodes are sized by
   # Karpenter (sku-family + CPU bounds below).
   system_node_vm_size = local.profile.system_node_vm_size

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -354,6 +354,28 @@ variable "observability_hostname" {
   }
 }
 
+variable "postgresql_backup_retention_days" {
+  description = "Days of automated PostgreSQL backups / point-in-time recovery. If null, chosen by size_profile (14 for prod, 7 for dev)."
+  type        = number
+  default     = null
+  validation {
+    # coalesce keeps floor() off a null value: Terraform before 1.12
+    # evaluates both sides of ||.
+    condition = (
+      coalesce(var.postgresql_backup_retention_days, 7) == floor(coalesce(var.postgresql_backup_retention_days, 7))
+      && coalesce(var.postgresql_backup_retention_days, 7) >= 7
+      && coalesce(var.postgresql_backup_retention_days, 7) <= 35
+    )
+    error_message = "postgresql_backup_retention_days must be a whole number of days between 7 and 35."
+  }
+}
+
+variable "postgresql_geo_redundant_backup" {
+  description = "Replicate PostgreSQL backups to the Azure paired region. Create-time only: changing it on an existing server destroys and recreates the database."
+  type        = bool
+  default     = false
+}
+
 variable "postgresql_sku_name" {
   description = "Azure Database for PostgreSQL SKU name. If null, chosen by size_profile. E.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3"
   type        = string


### PR DESCRIPTION
**Stack 3/7** — split out of #230. Base: #2 (`stack/2-iam`).

`rds_deletion_protection` defaulted to `false` and `rds_skip_final_snapshot` to `true`, but the size_profile fallback only fires on `null` — so the profile branch never ran and **prod silently got the dev behaviour**. Both are nullable now, and the resolution locals sit alongside the other profile-derived values.

Backup retention becomes profile-derived on both clouds (14 days prod, 7 dev), Azure gains an opt-in geo-redundant flag, and retention rejects fractional days.

> [!IMPORTANT]
> **Behaviour change.** The next apply against a prod workspace turns RDS deletion protection **on** and stops skipping the final snapshot. `terraform destroy` then needs an apply with `rds_deletion_protection = false` first — the example file now spells this out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable database backup retention for AWS and Azure environments.
  * Production profiles now default to longer retention and stronger deletion protection.
  * Added optional Azure geo-redundant PostgreSQL backups.
  * Enabled automatic storage growth for Azure PostgreSQL.
  * Added configurable AWS backup and maintenance windows.
  * Added validation for supported backup-retention settings.

* **Documentation**
  * Expanded example configuration guidance for backup retention, deletion protection, final snapshots, and geo-redundant backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->