### PR TITLE
refactor(ai-lake)!: rename the size profile and rework sizing presets

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -68,6 +68,14 @@ module "eks" {
     kube-proxy             = {}
     vpc-cni = {
       before_compute = true
+      # Prefix delegation: each ENI slot carries a /28, not one IP, so pod
+      # density stops tracking instance size. maxPods pinned to match below.
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
     }
     aws-ebs-csi-driver = {
       resolve_conflicts_on_create = "OVERWRITE"
@@ -87,10 +95,29 @@ module "eks" {
   # workload capacity just-in-time.
   eks_managed_node_groups = {
     system = {
-      ami_type                   = "BOTTLEROCKET_x86_64"
-      instance_types             = [local.system_node_type]
-      use_custom_launch_template = false
-      disk_size                  = 100
+      ami_type       = "BOTTLEROCKET_x86_64"
+      instance_types = [local.system_node_type]
+
+      # A custom launch template is what puts these nodes in the shared node
+      # security group. Bottlerocket stores containers on /dev/xvdb.
+      block_device_mappings = {
+        xvdb = {
+          device_name = "/dev/xvdb"
+          ebs = {
+            volume_size           = var.eks_node_disk_size
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
+
+      # Without this the kubelet keeps the secondary-IP pod limit, leaving
+      # prefix delegation inert here. EKS merges this with its own TOML.
+      bootstrap_extra_args = <<-EOT
+        [settings.kubernetes]
+        max-pods = ${var.eks_node_max_pods}
+      EOT
 
       # Isolate the system pool: only system pods (which tolerate this taint)
       # run here; all workloads go to Karpenter-provisioned nodes. CoreDNS
@@ -107,9 +134,11 @@ module "eks" {
 
       iam_role_additional_policies = local.node_iam_role_additional_policies
 
-      min_size     = 2
-      max_size     = 3
-      desired_size = 2
+      # Sized per size_profile (size-profiles.tf), matching AKS. One spare slot
+      # above desired so a node can be replaced without losing capacity.
+      min_size     = local.system_node_count
+      max_size     = local.system_node_count + 1
+      desired_size = local.system_node_count
     }
   }
 

--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -54,7 +54,7 @@ module "k8s_common" {
   gdcn_storage_class     = local.storage_class
   pulsar_size            = local.profile.pulsar_size
   observability_size     = local.profile.observability_size
-  starrocks_size_profile = var.starrocks_size_profile
+  ai_lake_size_profile   = var.ai_lake_size_profile
   cloud                  = "aws"
   ingress_controller     = var.ingress_controller
   gdcn_irsa_role_arn     = aws_iam_role.gdcn_irsa.arn

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -19,6 +19,10 @@ module "karpenter" {
   # association binding the kube-system/karpenter service account to the role.
   create_pod_identity_association = true
 
+  # The generated controller policy exceeds the 6144-char managed-policy quota.
+  # Inline role policies allow 10240, which fits.
+  enable_inline_policy = true
+
   # Lets Karpenter-launched nodes pull images (incl. via the optional
   # pull-through cache). Same policy set as the system node group.
   node_iam_role_additional_policies = local.node_iam_role_additional_policies
@@ -42,6 +46,9 @@ resource "helm_release" "karpenter" {
     serviceAccount = {
       name = "karpenter"
     }
+    # The chart's default 2 replicas require hostname anti-affinity to be
+    # satisfiable, so one system node means one replica.
+    replicas = min(local.system_node_count, 2)
     settings = {
       clusterName       = module.eks.cluster_name
       clusterEndpoint   = module.eks.cluster_endpoint
@@ -82,6 +89,22 @@ resource "kubectl_manifest" "karpenter_node_class" {
       tags = merge(local.common_tags, {
         "karpenter.sh/discovery" = var.deployment_name
       })
+      # Bottlerocket's default 20 GiB /dev/xvdb is below the ephemeral-storage
+      # some pods request, leaving them unschedulable on every instance type.
+      blockDeviceMappings = [{
+        deviceName = "/dev/xvdb"
+        ebs = {
+          volumeSize          = "${var.eks_node_disk_size}Gi"
+          volumeType          = "gp3"
+          encrypted           = true
+          deleteOnTermination = true
+        }
+      }]
+      # Karpenter sizes maxPods from secondary-IP limits, leaving prefix
+      # delegation (eks.tf) inert. 110 fits every node these pools build.
+      kubelet = {
+        maxPods = var.eks_node_max_pods
+      }
     }
   })
 
@@ -121,13 +144,16 @@ resource "kubectl_manifest" "karpenter_node_pool" {
           expireAfter = "720h"
         }
       }
-      # Total vCPU ceiling for this NodePool (size-profiles.tf).
+      # Total vCPU ceiling for this NodePool (size-profiles.tf). StarRocks pool
+      # below is uncapped (bounded by fixed replicas).
       limits = {
         cpu = local.eks_node_cpu_limit
       }
+      # 15m of underutilization before reclaiming a node, so bursty workloads
+      # do not churn capacity.
       disruption = {
         consolidationPolicy = "WhenEmptyOrUnderutilized"
-        consolidateAfter    = "1m"
+        consolidateAfter    = "15m"
       }
     }
   })
@@ -163,7 +189,7 @@ resource "kubectl_manifest" "karpenter_node_pool_starrocks" {
             { key = "kubernetes.io/arch", operator = "In", values = ["amd64"] },
             { key = "kubernetes.io/os", operator = "In", values = ["linux"] },
             { key = "karpenter.sh/capacity-type", operator = "In", values = ["on-demand"] },
-            { key = "node.kubernetes.io/instance-type", operator = "In", values = local.eks_starrocks_node_types },
+            { key = "node.kubernetes.io/instance-type", operator = "In", values = local.eks_ai_lake_node_types },
           ]
           nodeClassRef = {
             group = "karpenter.k8s.aws"

--- a/aws/settings.tfvars.example
+++ b/aws/settings.tfvars.example
@@ -145,9 +145,9 @@ gdcn_orgs = [
 # GoodData AI Lake (optional)
 ###
 # Uncomment to deploy AI Lake (additional license required). Both lines are
-# required; starrocks_size_profile is one of: dev, prod-small, prod-xl.
-# enable_ai_lake         = true
-# starrocks_size_profile = "prod-small"
+# required; ai_lake_size_profile is one of: dev, prod-small, prod-xl.
+# enable_ai_lake       = true
+# ai_lake_size_profile = "prod-small"
 
 ###
 # EKS & infrastructure (optional)

--- a/aws/size-profiles.tf
+++ b/aws/size-profiles.tf
@@ -1,9 +1,9 @@
 ###
-# Single source of truth for AWS sizing per size_profile: managed infra (RDS,
-# EKS nodes, Karpenter node CPU ceiling, ingress replicas) inline, plus workload
-# (GoodData.CN/Pulsar/observability) sizing referenced by name. StarRocks (AI
-# Lake) is sized separately via var.starrocks_size_profile. Override any managed
-# value via the matching var.* input.
+# All AWS sizing per size_profile. Managed infra (RDS, EKS system nodes,
+# Karpenter vCPU bounds, ingress replicas) is defined inline; GoodData.CN,
+# Pulsar and observability sizing is referenced by name. AI Lake has its own
+# tier, var.ai_lake_size_profile. Any managed value can be
+# overridden by the matching var.* input.
 ###
 
 locals {
@@ -13,11 +13,13 @@ locals {
         instance_class    = "db.t4g.medium"
         allocated_storage = 20
       }
-      system_node_type = "m6a.xlarge"
-      node_cpu_limit   = 48
-      node_cpu_max     = 8
-      ingress_replicas = 1
-      storage_class    = "gp3"
+      system_node_type   = "m6a.xlarge"
+      system_node_count  = 1
+      node_cpu_limit     = 48
+      node_cpu_max       = 8
+      ingress_replicas   = 1
+      storage_class      = "gp3"
+      fast_storage_class = "gp3"
       postgres = {
         work_mem_mb             = 8
         maintenance_work_mem_mb = 128
@@ -31,11 +33,13 @@ locals {
         instance_class    = "db.r6g.large"
         allocated_storage = 100
       }
-      system_node_type = "m8a.xlarge"
-      node_cpu_limit   = 96
-      node_cpu_max     = 8
-      ingress_replicas = 2
-      storage_class    = "gp3-perf"
+      system_node_type   = "m8a.xlarge"
+      system_node_count  = 2
+      node_cpu_limit     = 96
+      node_cpu_max       = 8
+      ingress_replicas   = 2
+      storage_class      = "gp3-perf"
+      fast_storage_class = "gp3-perf"
       postgres = {
         work_mem_mb             = 16
         maintenance_work_mem_mb = 256
@@ -49,11 +53,13 @@ locals {
         instance_class    = "db.r6g.xlarge"
         allocated_storage = 100
       }
-      system_node_type = "m8a.xlarge"
-      node_cpu_limit   = 320
-      node_cpu_max     = 16
-      ingress_replicas = 3
-      storage_class    = "gp3-perf"
+      system_node_type   = "m8a.xlarge"
+      system_node_count  = 3
+      node_cpu_limit     = 320
+      node_cpu_max       = 16
+      ingress_replicas   = 3
+      storage_class      = "gp3-perf"
+      fast_storage_class = "gp3-perf"
       postgres = {
         work_mem_mb             = 32
         maintenance_work_mem_mb = 512
@@ -67,27 +73,27 @@ locals {
         instance_class    = "db.r6g.2xlarge"
         allocated_storage = 200
       }
-      system_node_type = "m8a.xlarge"
-      node_cpu_limit   = 480
-      node_cpu_max     = 16
-      ingress_replicas = 3
-      storage_class    = "gp3-perf"
+      system_node_type   = "m8a.xlarge"
+      system_node_count  = 3
+      node_cpu_limit     = 480
+      node_cpu_max       = 16
+      ingress_replicas   = 3
+      storage_class      = "gp3-perf"
+      fast_storage_class = "gp3-perf"
       postgres = {
         work_mem_mb             = 64
         maintenance_work_mem_mb = 1024
       }
-      # No prod-xl GDCN/Pulsar/observability spec; fold to prod-large (explicit).
+      # There is no prod-xl workload spec, so prod-xl reuses prod-large.
       gdcn_size          = "prod-large"
       pulsar_size        = "prod-large"
       observability_size = "prod-large"
     }
   }
 
-  # StarRocks node pools are a separate dimension from size_profile: they are
-  # selected by var.starrocks_size_profile (dev/prod-small/prod-xl), which is
-  # decoupled from size_profile, so they live in their own map keyed only by the
-  # valid StarRocks tiers. There is intentionally no prod-large entry.
-  starrocks_node_type_presets = {
+  # Keyed by var.ai_lake_size_profile, which is chosen independently of
+  # size_profile. Only dev/prod-small/prod-xl exist; prod-large has no tier.
+  ai_lake_node_type_presets = {
     dev        = ["r8a.large", "m8a.xlarge"]
     prod-small = ["r8a.large", "r8a.xlarge"]
     prod-xl    = ["r8a.large", "r8a.8xlarge"]
@@ -95,27 +101,31 @@ locals {
 
   profile = local.size_profiles[var.size_profile]
 
-  # Resolved size_profile values (profile default, overridable via var.*).
+  # Resolved values: profile default unless the matching var.* is set.
   rds_instance_class    = coalesce(var.rds_instance_class, local.profile.rds.instance_class)
   rds_allocated_storage = coalesce(var.rds_allocated_storage, local.profile.rds.allocated_storage)
-  # Lifecycle and backups follow the profile unless the matching var.* is set.
+  # Prod keeps deletion protection, a final snapshot on destroy, and 14 days of
+  # point-in-time recovery; dev is disposable and keeps 7 days.
   rds_is_prod                 = startswith(var.size_profile, "prod")
   rds_deletion_protection     = var.rds_deletion_protection != null ? var.rds_deletion_protection : local.rds_is_prod
   rds_skip_final_snapshot     = var.rds_skip_final_snapshot != null ? var.rds_skip_final_snapshot : !local.rds_is_prod
   rds_backup_retention_period = coalesce(var.rds_backup_retention_period, local.rds_is_prod ? 14 : 7)
-  # System node group instance type (not user-configurable). Workload nodes are
-  # sized by Karpenter (instance-category + CPU bounds below).
-  system_node_type = local.profile.system_node_type
-  # Total workload vCPU ceiling (NodePool spec.limits.cpu).
+  # Instance type and count of the system node group; not user-configurable.
+  # Karpenter sizes the workload nodes, using the vCPU bounds below.
+  system_node_type  = local.profile.system_node_type
+  system_node_count = local.profile.system_node_count
+  # Ceiling on total workload vCPUs Karpenter may run (NodePool spec.limits.cpu).
   eks_node_cpu_limit = coalesce(var.eks_node_cpu_limit, local.profile.node_cpu_limit)
-  # Per-node vCPU cap for workload nodes (NodePool instance-cpu Lt) within the m category.
+  # Largest workload node Karpenter may pick, in vCPUs (NodePool instance-cpu Lt).
+  # The m*a types it selects from have no member below 2 vCPU, so no floor is set.
   eks_node_cpu_max = coalesce(var.eks_node_cpu_max, local.profile.node_cpu_max)
-  # StorageClass for GoodData.CN chart PVCs (gp3 for dev, gp3-perf for prod).
-  # Overridable via var.eks_storage_class.
+  # StorageClass for GoodData.CN chart PVCs. Overridable via var.eks_storage_class.
   storage_class = coalesce(var.eks_storage_class, local.profile.storage_class)
+  # Class for latency-sensitive PVCs, etcd only for now. Differs from the default
+  # class by throughput, at an IOPS level valid for any volume size.
+  fast_storage_class = local.profile.fast_storage_class
 
-  # StarRocks node pool: indexed by the explicit var.starrocks_size_profile, NOT
-  # size_profile (the two are decoupled). Only used when enable_ai_lake is true,
-  # which the variable's validation requires.
-  eks_starrocks_node_types = var.enable_ai_lake ? coalesce(var.eks_starrocks_node_types, local.starrocks_node_type_presets[var.starrocks_size_profile]) : []
+  # AI Lake node types come from var.ai_lake_size_profile, not size_profile.
+  # Empty unless AI Lake is enabled, since nothing consumes them otherwise.
+  eks_ai_lake_node_types = var.enable_ai_lake ? coalesce(var.eks_ai_lake_node_types, local.ai_lake_node_type_presets[var.ai_lake_size_profile]) : []
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,3 +1,17 @@
+variable "ai_lake_size_profile" {
+  description = "AI Lake sizing profile. Required when enable_ai_lake is true; one of: dev, prod-small, prod-xl. Not derived from size_profile."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.ai_lake_size_profile == null || contains(["dev", "prod-small", "prod-xl"], var.ai_lake_size_profile)
+    error_message = "ai_lake_size_profile must be one of: dev, prod-small, prod-xl."
+  }
+  validation {
+    condition     = !var.enable_ai_lake || var.ai_lake_size_profile != null
+    error_message = "ai_lake_size_profile must be set when enable_ai_lake is true."
+  }
+}
+
 variable "auth_hostname" {
   description = "Hostname for the default GoodData identity provider (Dex) ingress."
   type        = string
@@ -66,6 +80,12 @@ variable "dockerhub_username" {
   }
 }
 
+variable "eks_ai_lake_node_types" {
+  description = "EC2 instance types for the dedicated AI Lake node pool (taint workload=starrocks). If null, defaults to a preset chosen by ai_lake_size_profile."
+  type        = list(string)
+  default     = null
+}
+
 variable "eks_endpoint_private_access" {
   description = "Whether the EKS API server is reachable privately from within the VPC."
   type        = bool
@@ -100,14 +120,20 @@ variable "eks_node_cpu_max" {
   default     = null
 }
 
-variable "eks_starrocks_node_types" {
-  description = "EC2 instance types for the StarRocks-dedicated EKS pool (taint workload=starrocks). If null, defaults to a preset chosen by starrocks_size_profile."
-  type        = list(string)
-  default     = null
+variable "eks_node_disk_size" {
+  description = "Data volume size in GiB for every node's /dev/xvdb, on both the system node group and the Karpenter EC2NodeClass. Bottlerocket otherwise defaults to 20 GiB, which is below the ephemeral-storage some GoodData.CN pods request and leaves them unschedulable on every instance type."
+  type        = number
+  default     = 100
+}
+
+variable "eks_node_max_pods" {
+  description = "Kubelet maxPods for every node, set on the Karpenter EC2NodeClass and in the system node group's Bottlerocket settings. Both otherwise derive it from the instance type's secondary-IP limits, which leaves VPC CNI prefix delegation inert. 110 is the AWS-recommended ceiling for instances under 30 vCPU."
+  type        = number
+  default     = 110
 }
 
 variable "eks_storage_class" {
-  description = "Kubernetes StorageClass for GoodData.CN chart PVCs. If null, chosen by size_profile (gp3 for dev, gp3-perf for prod)."
+  description = "Kubernetes StorageClass for GoodData.CN chart PVCs. If null, chosen by size_profile. Latency-sensitive PVCs use the fast class instead, which is not user-configurable."
   type        = string
   default     = null
 }
@@ -143,7 +169,7 @@ variable "enable_observability" {
 }
 
 variable "enable_ai_lake" {
-  description = "Enable StarRocks deployment for analytics query acceleration"
+  description = "Enable AI Lake deployment for analytics query acceleration"
   type        = bool
   default     = false
 }
@@ -498,20 +524,6 @@ variable "starrocks_fe_image_tag" {
   description = "Docker image tag for StarRocks FE nodes"
   type        = string
   default     = "4.0.6-20260507-091022-3c12ee9"
-}
-
-variable "starrocks_size_profile" {
-  description = "StarRocks (AI Lake) sizing profile. Required when enable_ai_lake is true; one of: dev, prod-small, prod-xl. Not derived from size_profile."
-  type        = string
-  default     = null
-  validation {
-    condition     = var.starrocks_size_profile == null || contains(["dev", "prod-small", "prod-xl"], var.starrocks_size_profile)
-    error_message = "starrocks_size_profile must be one of: dev, prod-small, prod-xl."
-  }
-  validation {
-    condition     = !var.enable_ai_lake || var.starrocks_size_profile != null
-    error_message = "starrocks_size_profile must be set when enable_ai_lake is true."
-  }
 }
 
 variable "tls_mode" {

--- a/aws/vpc-endpoints.tf
+++ b/aws/vpc-endpoints.tf
@@ -3,7 +3,7 @@
 ###
 
 # S3 gateway endpoint: routes S3 traffic (Quiver cache, datasource FS, exports,
-# StarRocks) over the AWS backbone instead of the NAT gateway, eliminating NAT
+# AI Lake) over the AWS backbone instead of the NAT gateway, eliminating NAT
 # data-processing charges on blob I/O. Gateway endpoints are free. Only created
 # for VPCs we manage; bring-your-own-VPC users add their own.
 resource "aws_vpc_endpoint" "s3" {

--- a/azure/karpenter.tf
+++ b/azure/karpenter.tf
@@ -37,9 +37,8 @@ resource "kubectl_manifest" "karpenter_node_class" {
 # All listed series are premium-storage capable, which in Azure costs the same
 # per hour as the (now v4-only) non-premium variants, so there is no reason to
 # admit non-premium SKUs and force premium-PVC pods onto per-pod nodeAffinity.
-# Spanning v5-v7 keeps a wide capacity pool; Karpenter prefers the cheapest
-# (v6/v7) and falls back to v5 only on shortage. sku-cpu + the CPU limit bound
-# node size and total cost.
+# v6/v7 only, so nodes are always current-generation. sku-cpu + the CPU limit
+# bound node size and total cost.
 resource "kubectl_manifest" "karpenter_node_pool" {
   yaml_body = yamlencode({
     apiVersion = "karpenter.sh/v1"
@@ -56,7 +55,9 @@ resource "kubectl_manifest" "karpenter_node_pool" {
             { key = "karpenter.sh/capacity-type", operator = "In", values = ["on-demand"] },
             # AMD general-purpose, 4 GiB/vCPU, premium-capable D-series only.
             # Excludes Intel (Ds/Dls), low-memory (Dals/Dls), and ARM (Dpls).
-            { key = "karpenter.azure.com/sku-series", operator = "In", values = ["Das_v5", "Das_v6", "Das_v7"] },
+            # Smallest member (D2as) gives an implicit 2 vCPU floor, so no Gt
+            # requirement is needed here.
+            { key = "karpenter.azure.com/sku-series", operator = "In", values = ["Das_v6", "Das_v7"] },
             { key = "karpenter.azure.com/sku-cpu", operator = "Lt", values = [tostring(local.aks_node_cpu_max + 1)] },
             # Belt-and-suspenders: the series above are all premium-capable, but
             # keep this so a stray non-premium series can never admit a node that

--- a/azure/postgresql.tf
+++ b/azure/postgresql.tf
@@ -44,16 +44,17 @@ resource "azurerm_postgresql_flexible_server" "main" {
   administrator_login    = local.db_username
   administrator_password = local.db_password
   storage_mb             = local.postgresql_storage_mb
+  storage_tier           = local.postgresql_storage_tier
   sku_name               = local.postgresql_sku_name
 
   # Disable public network access when using VNet integration
   public_network_access_enabled = false
 
   backup_retention_days = local.postgresql_backup_retention_days
+  auto_grow_enabled     = true
   # Backups in the paired region. Opt-in, not profile-derived: Azure only accepts
   # this at create time, so changing it recreates the server (destroying the DB).
   geo_redundant_backup_enabled = var.postgresql_geo_redundant_backup
-  auto_grow_enabled            = true
 
   maintenance_window {
     day_of_week  = 0

--- a/azure/size-profiles.tf
+++ b/azure/size-profiles.tf
@@ -1,16 +1,20 @@
 ###
-# Single source of truth for Azure sizing per size_profile: managed infra
-# (PostgreSQL, AKS nodes, Karpenter/NAP node CPU ceiling, ingress replicas) inline, plus
-# workload (GoodData.CN/Pulsar/observability) sizing referenced by name. prod-xl
-# is not valid on Azure. Override any managed value via the matching var.* input.
+# All Azure sizing per size_profile. Managed infra (PostgreSQL, AKS system
+# nodes, Karpenter/NAP vCPU bounds, ingress replicas) is defined inline;
+# GoodData.CN, Pulsar and observability sizing is referenced by name. prod-xl
+# is AWS-only. Managed values are overridable by the matching var.* input where
+# one exists. PostgreSQL storage size takes its default from the profile; its
+# performance tier is pinned by the profile, and Azure derives it once the size
+# is overridden.
 ###
 
 locals {
   size_profiles = {
     dev = {
       postgresql = {
-        sku_name   = "B_Standard_B2s"
-        storage_mb = 32768
+        sku_name     = "B_Standard_B2s"
+        storage_mb   = 32768
+        storage_tier = null
       }
       postgres = {
         work_mem_mb             = 8
@@ -20,8 +24,8 @@ locals {
       aks_node_counts = {
         min = 1
       }
-      node_cpu_limit     = 24
-      node_cpu_max       = 4
+      node_cpu_limit     = 48
+      node_cpu_max       = 8
       storage_class      = "managed-csi"
       ingress_replicas   = 1
       gdcn_size          = "dev"
@@ -30,8 +34,11 @@ locals {
     }
     prod-small = {
       postgresql = {
-        sku_name   = "GP_Standard_D4ds_v5"
-        storage_mb = 131072
+        sku_name = "GP_Standard_D4ds_v5"
+        # 128 GB is the smallest step at or above 100 GB; autogrow (postgresql.tf)
+        # grows it. P20 pins ~2300 IOPS, which untiered storage needs 512 GB for.
+        storage_mb   = 131072
+        storage_tier = "P20"
       }
       postgres = {
         work_mem_mb             = 16
@@ -51,10 +58,9 @@ locals {
     }
     prod-large = {
       postgresql = {
-        sku_name = "MO_Standard_E8ds_v5"
-        # 512 GB for IOPS headroom under load (v1 storage IOPS scale with size:
-        # ~2300 @ 512 GB vs ~500 @ 128 GB). Overridable via var.postgresql_storage_mb.
-        storage_mb = 524288
+        sku_name     = "MO_Standard_E8ds_v5"
+        storage_mb   = 524288
+        storage_tier = "P20"
       }
       postgres = {
         work_mem_mb             = 32
@@ -76,21 +82,29 @@ locals {
 
   profile = local.size_profiles[var.size_profile]
 
-  # Resolved managed values (profile default, overridable via var.*).
+  # Resolved values: profile default unless the matching var.* is set.
   postgresql_sku_name = coalesce(var.postgresql_sku_name, local.profile.postgresql.sku_name)
+  # Azure rejects a tier below the one the size implies. dev leaves the tier null
+  # and lets Azure derive it; prod pins P20 to buy IOPS without a bigger disk.
+  # Overriding the size drops the pin entirely rather than exposing a tier input:
+  # a bigger disk derives a higher tier anyway, and this leaves no way to state a
+  # pair Azure would reject. Pinning a tier above a *smaller* disk would need the
+  # size->tier table, so add it here if that case ever comes up.
+  postgresql_storage_mb   = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
+  postgresql_storage_tier = var.postgresql_storage_mb != null ? null : local.profile.postgresql.storage_tier
   # Prod keeps 14 days of point-in-time recovery, dev the 7-day minimum.
   postgresql_is_prod               = startswith(var.size_profile, "prod")
   postgresql_backup_retention_days = coalesce(var.postgresql_backup_retention_days, local.postgresql_is_prod ? 14 : 7)
-  postgresql_storage_mb            = coalesce(var.postgresql_storage_mb, local.profile.postgresql.storage_mb)
   aks_min_nodes                    = coalesce(var.aks_min_nodes, local.profile.aks_node_counts.min)
-  # System pool VM size (not user-configurable). Workload nodes are sized by
-  # Karpenter (sku-family + CPU bounds below).
+  # VM size of the system pool; not user-configurable. Karpenter sizes the
+  # workload nodes, using the vCPU bounds below.
   system_node_vm_size = local.profile.system_node_vm_size
-  # Total workload vCPU ceiling (NodePool spec.limits.cpu).
+  # Ceiling on total workload vCPUs Karpenter may run (NodePool spec.limits.cpu).
   aks_node_cpu_limit = coalesce(var.aks_node_cpu_limit, local.profile.node_cpu_limit)
-  # Per-node vCPU cap for workload nodes (NodePool sku-cpu Lt) within the D family.
+  # Largest workload node Karpenter may pick, in vCPUs (NodePool sku-cpu Lt).
+  # The Das series it selects from has no member below 2 vCPU, so no floor is set.
   aks_node_cpu_max = coalesce(var.aks_node_cpu_max, local.profile.node_cpu_max)
-  # StorageClass for GoodData.CN chart PVCs (standard for dev, premium for prod).
-  # Overridable via var.azure_storage_class.
+  # StorageClass for GoodData.CN chart PVCs: managed-csi on dev,
+  # premium-ssd-v2 on prod.
   storage_class = coalesce(var.azure_storage_class, local.profile.storage_class)
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -376,17 +376,18 @@ variable "postgresql_geo_redundant_backup" {
   default     = false
 }
 
+variable "postgresql_storage_mb" {
+  description = "Azure Database for PostgreSQL storage in MB. If null, chosen by size_profile. Set this if auto_grow_enabled has raised the disk above the profile value, since Azure rejects storage decreases."
+  type        = number
+  default     = null
+}
+
 variable "postgresql_sku_name" {
   description = "Azure Database for PostgreSQL SKU name. If null, chosen by size_profile. E.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3"
   type        = string
   default     = null
 }
 
-variable "postgresql_storage_mb" {
-  description = "Azure Database for PostgreSQL storage in MB. If null, chosen by size_profile."
-  type        = number
-  default     = null
-}
 
 variable "size_profile" {
   description = "Sizing profile for GoodData.CN and supporting services."

--- a/local/size-profiles.tf
+++ b/local/size-profiles.tf
@@ -1,8 +1,8 @@
 ###
-# Single source of truth for local (k3d) sizing. Local supports only "dev"
-# (smallest, non-HA). Holds the in-cluster postgres (CNPG) sizing inline plus
-# workload (GoodData.CN/Pulsar/observability) sizing referenced by name.
-# StarRocks (AI Lake) is not supported on local.
+# All local (k3d) sizing; "dev" is the only profile local supports. The
+# in-cluster Postgres (CNPG) sizing is defined inline; GoodData.CN, Pulsar and
+# observability sizing is referenced by name. AI Lake is not supported
+# on local.
 ###
 
 locals {

--- a/modules/k8s-common/size-profiles.tf
+++ b/modules/k8s-common/size-profiles.tf
@@ -3,8 +3,8 @@
 # the same across AWS/Azure/local at a given tier, so they live here once and
 # the environment selects a tier by name via var.observability_size. Only the
 # observability stack (no per-tier Helm chart) is sized here; GoodData.CN,
-# Pulsar, and StarRocks sizing is selected by var.gdcn_size / var.pulsar_size /
-# var.starrocks_size_profile against templates/*-size-<tier>.yaml.tftpl and
+# Pulsar, and AI Lake sizing is selected by var.gdcn_size / var.pulsar_size /
+# var.ai_lake_size_profile against templates/*-size-<tier>.yaml.tftpl and
 # starrocks.tf, not this file.
 #
 # Observability CPU is intentionally left flat per-service (these components are

--- a/modules/k8s-common/starrocks.tf
+++ b/modules/k8s-common/starrocks.tf
@@ -1,15 +1,14 @@
 ###
-# Deploy StarRocks in shared-data mode (FE + CN, S3 storage)
+# Deploy the StarRocks engine behind AI Lake, in shared-data mode (FE + CN,
+# S3 storage)
 ###
 
 resource "kubernetes_namespace_v1" "starrocks" {
   count = var.enable_ai_lake ? 1 : 0
 
   metadata {
-    name = local.starrocks_namespace
-    labels = local.use_istio_gateway ? {
-      "istio-injection" = "enabled"
-    } : null
+    name   = local.starrocks_namespace
+    labels = local.istio_injection_labels
   }
 }
 
@@ -127,7 +126,7 @@ resource "helm_release" "starrocks" {
       enable_observability      = var.enable_observability
       starrocks_fe_image_tag    = var.starrocks_fe_image_tag
       starrocks_cn_image_tag    = var.starrocks_cn_image_tag
-      fe_java_heap_mb           = local.starrocks_fe_heap_mb[var.starrocks_size_profile]
+      fe_java_heap_mb           = local.starrocks_fe_heap_mb[var.ai_lake_size_profile]
     }),
     var.cloud == "aws" ? templatefile("${path.module}/templates/starrocks-aws.yaml.tftpl", {
       starrocks_irsa_role_arn      = var.starrocks_irsa_role_arn
@@ -138,10 +137,10 @@ resource "helm_release" "starrocks" {
       aws_account_id               = var.aws_account_id
       starrocks_s3_bucket_id       = var.starrocks_s3_bucket_id
       s3_tables_bucket_name        = var.starrocks_s3_tables_bucket_name
-      fe_java_heap_mb              = local.starrocks_fe_heap_mb[var.starrocks_size_profile]
+      fe_java_heap_mb              = local.starrocks_fe_heap_mb[var.ai_lake_size_profile]
       node_workload_label          = "starrocks"
     }) : null,
-    templatefile("${path.module}/templates/starrocks-size-${var.starrocks_size_profile}.yaml.tftpl", {}),
+    templatefile("${path.module}/templates/starrocks-size-${var.ai_lake_size_profile}.yaml.tftpl", {}),
   ])
 
   wait          = true

--- a/modules/k8s-common/templates/gdcn-ai-lake.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-ai-lake.yaml.tftpl
@@ -19,7 +19,7 @@ aiLake:
     extraConfig:
       override.toml: |
 %{ for org_id in organization_ids ~}
-        # StarRocks cluster for ${org_id} org
+        # StarRocks compute cluster for ${org_id} org
         [compute_clusters.${org_id}]
         name = "starrocks-${org_id}"
         organization_id = "${org_id}"

--- a/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-large.yaml.tftpl
@@ -3,7 +3,7 @@
 # High-traffic multi-tenant sizing: more hot-path replicas + CPU/memory than
 # prod-small, dedicated Quiver policy nodes, larger result cache.
 #
-# StarRocks (AI Lake) is sized separately via var.starrocks_size_profile
+# AI Lake is sized separately via var.ai_lake_size_profile
 # (dev/prod-small/prod-xl); it is not derived from this profile.
 
 replicaCount: 2
@@ -23,9 +23,6 @@ platform_limits:
 # Deploy dedicated Quiver policy nodes so policy-handling load is taken off the
 # cache nodes, preventing hiccups during high load and releases.
 deployDedicatedPolicyNodes: true
-
-# Deploy dedicated Quiver datasource-filesystem nodes to offload datasource reads.
-deployQuiverDatasourceFs: true
 
 # Long-poll AFM execution results instead of client polling.
 enableAfmLongPoll: true
@@ -86,13 +83,13 @@ automation:
       value: "false"
 calcique:
   jvmOptions: -Xmx1024M -XX:MaxMetaspaceSize=320M -XX:MaxDirectMemorySize=512M
-  replicaCount: 4
+  replicaCount: 2
   resources:
     limits:
-      cpu: 1500m
+      cpu: 3000m
       memory: 2800Mi
     requests:
-      cpu: 300m
+      cpu: 1500m
       memory: 2800Mi
 customEtcd:
   enabled: true
@@ -103,8 +100,14 @@ customEtcd:
     limits:
       cpu: 2000m
       memory: 4096Mi
+  # Down from 512Gi, which was far more than etcd can use. A StatefulSet
+  # volumeClaimTemplate is immutable, so an existing prod-large install rejects
+  # this on upgrade. Migrating means snapshotting etcd, deleting the
+  # StatefulSet with --cascade=orphan plus its PVCs, then re-applying and
+  # restoring — do not delete PVCs without a snapshot, the flight catalog
+  # lives on that disk.
   persistence:
-    size: 512Gi
+    size: 30Gi
 dashboards:
   resources:
     limits:
@@ -257,8 +260,8 @@ quiver:
     # cache serves every DoGet + absorbs DoPut/S3 writes on cache miss; 2 pods
     # saturated the put pipeline under load.
     cache: 8
-    # xtab is I/O-bound (Flight reads from cache); scaled to 18 pods plus widened
-    # worker pools (extraEnvVarsXtab) to keep the cross-tab queue clear under load.
+    # xtab is I/O-bound (Flight reads from cache); 8 pods with capped worker
+    # pools (extraEnvVarsXtab) keep the queue clear without swamping the cache.
     xtab: 8
   resources:
     cache:
@@ -281,9 +284,8 @@ quiver:
         memory: 7680Mi
       requests:
         cpu: 2000m
-        # Steady-state RSS runs well above the old request, letting the scheduler
-        # overcommit nodes and evict xtab pods under load. Request is set above
-        # observed peak (still below the limit).
+        # Set above observed peak RSS (still under the limit) so the scheduler
+        # can't overcommit nodes and evict xtab pods under load.
         memory: 5120Mi
     ml:
       limits:
@@ -361,10 +363,10 @@ redis-ha:
       maxmemory: 7300m
     resources:
       limits:
-        cpu: 1500m
+        cpu: 2000m
         memory: 9125Mi
       requests:
-        cpu: 700m
+        cpu: 1500m
         memory: 9125Mi
   sentinel:
     resources:

--- a/modules/k8s-common/templates/gdcn-size-prod-small.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-size-prod-small.yaml.tftpl
@@ -77,6 +77,16 @@ customEtcd:
     limits:
       cpu: 600m
       memory: 1024Mi
+  # Above the chart's 8Gi default: etcd holds Quiver's flight catalog, and a full
+  # volume wedges writes.
+  #
+  # This grows the volume, so no data has to move: gp3 and premium-ssd-v2 both
+  # allow expansion. The StatefulSet still blocks the upgrade, because
+  # volumeClaimTemplates is immutable — delete it with --cascade=orphan, patch
+  # each etcd PVC to the new size, then re-apply. Keep the PVCs; unlike the
+  # prod-large shrink, nothing here needs a restore.
+  persistence:
+    size: 20Gi
 dashboards:
   resources:
     limits:

--- a/modules/k8s-common/templates/starrocks-aws.yaml.tftpl
+++ b/modules/k8s-common/templates/starrocks-aws.yaml.tftpl
@@ -9,8 +9,8 @@ operator:
 
 starrocks:
   starrocksFESpec:
-    # Bind FE pods to the dedicated StarRocks managed node group
-    # (matches taint workload=starrocks:NoSchedule applied in aws/eks.tf).
+    # Bind FE pods to the dedicated StarRocks node pool
+    # (matches taint workload=starrocks:NoSchedule set in aws/karpenter.tf).
     nodeSelector:
       workload: ${node_workload_label}
     tolerations:
@@ -176,8 +176,8 @@ starrocks:
             memory: 256Mi
 
   starrocksCnSpec:
-    # Bind CN pods to the dedicated StarRocks managed node group
-    # (matches taint workload=starrocks:NoSchedule applied in aws/eks.tf).
+    # Bind CN pods to the dedicated StarRocks node pool
+    # (matches taint workload=starrocks:NoSchedule set in aws/karpenter.tf).
     nodeSelector:
       workload: ${node_workload_label}
     tolerations:

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -1,3 +1,9 @@
+# Required only when enable_ai_lake is true (AI Lake is AWS-only); null otherwise.
+variable "ai_lake_size_profile" {
+  type    = string
+  default = null
+}
+
 variable "auth_hostname" { type = string }
 
 variable "aws_region" {
@@ -85,7 +91,7 @@ variable "glue_etl_role_arn" {
 }
 
 variable "starrocks_s3_tables_iam_user_arn" {
-  description = "ARN of the IAM user used by StarRocks to access AWS S3 Tables."
+  description = "ARN of the IAM user used by AI Lake to access AWS S3 Tables."
   type        = string
   default     = ""
 }
@@ -287,12 +293,6 @@ variable "pulsar_size" {
     condition     = contains(local.workload_size_tiers, var.pulsar_size)
     error_message = "pulsar_size must be one of: ${join(", ", local.workload_size_tiers)} (fold prod-xl to prod-large in the env's size-profiles.tf)."
   }
-}
-
-# Required only when enable_ai_lake is true (StarRocks is AWS-only); null otherwise.
-variable "starrocks_size_profile" {
-  type    = string
-  default = null
 }
 
 variable "starrocks_cn_image_tag" {


### PR DESCRIPTION
**Stack 4/7** — split out of #230. Base: #3 (`stack/3-db`).

> [!WARNING]
> **BREAKING.** `starrocks_size_profile` → `ai_lake_size_profile`, and `eks_starrocks_node_types` → `eks_ai_lake_node_types`. Update `settings.tfvars` before applying.

The StarRocks engine is an implementation detail of AI Lake, so the inputs are named for the feature rather than the engine. Verified no references to the old names remain anywhere in the repo.

Sizing alongside it:
- System node group count comes from the profile instead of a hardcoded 2, matching AKS, with one spare slot above desired.
- AI Lake node types resolve from a per-profile preset when unset.
- Prefix delegation on the VPC CNI with a matching `max-pods`, so pod density stops tracking instance size.
- Bottlerocket nodes get an explicit `/dev/xvdb` mapping; the default 20 GiB is below what some pods request.
- prod-large etcd drops from 512Gi. A StatefulSet `volumeClaimTemplate` cannot shrink in place, so an existing prod-large install needs its etcd PVCs recreated — confirmed with the maintainer that nothing is running on the old size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AI Lake sizing profiles and dedicated compute instance options.
  * Added configurable Kubernetes node disk capacity and pod limits.
  * Added AWS fast-storage options and Azure PostgreSQL storage tiers.
  * Enabled improved AWS networking capacity through prefix delegation.

* **Improvements**
  * Updated production sizing to balance storage, compute, caching, and service resources.
  * Improved node scaling and workload placement across AWS and Azure.
  * Enhanced PostgreSQL storage growth handling on Azure.

* **Documentation**
  * Updated configuration guidance and terminology to consistently reference AI Lake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->