### PR TITLE
feat(storage): encrypt gp3 and give etcd its own storage class

### DIFF
--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -54,6 +54,7 @@ module "k8s_common" {
   gdcn_storage_class     = local.storage_class
   pulsar_size            = local.profile.pulsar_size
   observability_size     = local.profile.observability_size
+  fast_storage_class     = local.fast_storage_class
   ai_lake_size_profile   = var.ai_lake_size_profile
   cloud                  = "aws"
   ingress_controller     = var.ingress_controller

--- a/azure/storage-class.tf
+++ b/azure/storage-class.tf
@@ -28,7 +28,10 @@ resource "kubernetes_storage_class_v1" "premium_ssd_v2" {
     DiskMBpsReadWrite = "125"
   }
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }
 
 # Premium SSD v1 (Premium_LRS) kept as a non-default class so workloads can pin
@@ -51,7 +54,10 @@ resource "kubernetes_storage_class_v1" "premium_ssd" {
     skuname = "Premium_LRS"
   }
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }
 
 # Cluster default = the built-in StandardSSD class "managed-csi" (standard tier).
@@ -81,5 +87,8 @@ resource "kubernetes_annotations" "default_storage_class" {
   # take ownership of it rather than erroring on the conflict.
   force = true
 
-  depends_on = [azurerm_kubernetes_cluster.main]
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+    azurerm_role_assignment.aks_creator_cluster_admin,
+  ]
 }

--- a/modules/k8s-aws/storage-class.tf
+++ b/modules/k8s-aws/storage-class.tf
@@ -2,6 +2,11 @@
 # Configure Kubernetes storage class
 ###
 
+# encrypted = "true" on both classes, so PVC data is encrypted at rest even if
+# the account has no default-encryption setting. kmsKeyId is deliberately unset,
+# which means each volume uses whichever key the account has configured as its
+# EBS default — aws/managed unless someone has pointed it at a CMK.
+
 resource "kubernetes_storage_class_v1" "gp3_perf" {
   metadata {
     name = "gp3-perf"
@@ -12,10 +17,14 @@ resource "kubernetes_storage_class_v1" "gp3_perf" {
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
 
+  # Fast class for latency-sensitive PVCs. 3000 IOPS is the ceiling valid at any
+  # size; above it EBS caps gp3 provisioned IOPS at 500/GiB. Throughput is the
+  # real gain here: 300 MBps against the 125 the default class gets free.
   parameters = {
     type       = "gp3"
-    iops       = "5000"
+    iops       = "3000"
     throughput = "300"
+    encrypted  = "true"
   }
 }
 
@@ -34,6 +43,7 @@ resource "kubernetes_storage_class_v1" "gp3" {
   allow_volume_expansion = true
 
   parameters = {
-    type = "gp3"
+    type      = "gp3"
+    encrypted = "true"
   }
 }

--- a/modules/k8s-common/gooddata-cn.tf
+++ b/modules/k8s-common/gooddata-cn.tf
@@ -16,6 +16,7 @@ locals {
   ingress_annotations     = merge(local.ingress_annotation_defaults, var.ingress_annotations_override)
   dex_ingress_annotations = merge(local.dex_annotation_defaults, var.dex_ingress_annotations_override)
   dex_tls_enabled         = local.use_cert_manager
+  fast_storage_class      = var.fast_storage_class != "" ? var.fast_storage_class : var.gdcn_storage_class
 }
 
 # Enforce STRICT mTLS for all inbound traffic to workloads in the GoodData.CN namespace.
@@ -122,6 +123,7 @@ resource "helm_release" "gooddata_cn" {
       db_username             = var.db_username
       db_password             = var.db_password
       storage_class           = var.gdcn_storage_class
+      fast_storage_class      = local.fast_storage_class
       registry_dockerio       = var.registry_dockerio
       registry_quayio         = var.registry_quayio
       ingress_class_name      = local.resolved_ingress_class_name

--- a/modules/k8s-common/templates/gdcn-base.yaml.tftpl
+++ b/modules/k8s-common/templates/gdcn-base.yaml.tftpl
@@ -81,13 +81,23 @@ tools:
 # Disable telemetry
 telemetry:
   enabled: false
-%{ if storage_class != "" }
+%{ if fast_storage_class != "" }
 
-# Pin PVC storage class per size profile (set from Terraform). Covers the
-# always-present chart PVCs (etcd, redis-ha) and qdrant when AI features are on.
+# etcd takes the fast class, since Quiver blocks on its fsync latency. Rendered
+# on its own so fast_storage_class still applies when gdcn_storage_class is
+# unset (it falls back to gdcn_storage_class when empty).
+#
+# storageClassName lands in a StatefulSet volumeClaimTemplate, which is
+# immutable: changing it on an existing release is rejected on upgrade. Treat
+# it as a new-deployment setting unless you migrate the etcd PVCs.
 customEtcd:
   persistence:
-    storageClassName: ${storage_class}
+    storageClassName: ${fast_storage_class}
+%{ endif ~}
+%{ if storage_class != "" }
+
+# Pin the remaining chart PVCs per size profile (set from Terraform): redis-ha
+# is always present, qdrant only when AI features are on.
 redis-ha:
   persistentVolume:
     storageClass: ${storage_class}

--- a/modules/k8s-common/variables.tf
+++ b/modules/k8s-common/variables.tf
@@ -72,6 +72,12 @@ variable "enable_ai_lake" {
   default     = false
 }
 
+variable "fast_storage_class" {
+  description = "StorageClass for latency-sensitive GoodData.CN PVCs (etcd today). Falls back to gdcn_storage_class when empty."
+  type        = string
+  default     = ""
+}
+
 variable "s3_tables_bucket_arn" {
   description = "ARN of the AWS S3 Tables bucket used by AI Lake."
   type        = string
@@ -274,7 +280,7 @@ variable "gdcn_size" {
 }
 
 variable "gdcn_storage_class" {
-  description = "Kubernetes StorageClass for GoodData.CN chart PVCs (etcd, redis-ha, qdrant). Empty string leaves them on the cluster default class."
+  description = "Kubernetes StorageClass for GoodData.CN chart PVCs (redis-ha, qdrant, and etcd when fast_storage_class is unset). Empty string leaves them on the cluster default class."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
**Stack 5/7** — split out of #230. Base: #4 (`stack/4-sizing`).

- `gp3` and `gp3-perf` StorageClasses set `encrypted = true`. AWS-managed keys, so no key management.
- New `fast_storage_class` input, resolved per size profile, pins the etcd PVC to the low-latency class since Quiver blocks on its fsync latency. Rendered independently of `gdcn_storage_class`, so setting only the fast class works — verified all four combinations render and parse as YAML.
- Azure StorageClass creation waits on the cluster-admin role assignment.

> [!IMPORTANT]
> Applying **replaces** the gp3 StorageClasses, since their parameters are immutable — new PVCs are briefly Pending while that happens. Existing volumes are unaffected; encryption applies to newly provisioned ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated fast storage class for latency-sensitive GoodData.CN data.
  * Automatically falls back to the standard storage class when no fast storage class is configured.
  * Applies the fast class specifically to etcd while retaining standard storage for other components.

* **Improvements**
  * Enabled encryption for AWS EBS storage classes.
  * Optimized gp3 performance settings for improved compatibility.
  * Improved storage provisioning reliability by ensuring required permissions are established first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->