### PR TITLE
fix(lifecycle): bootstrap tolerations and safe destroy ordering

### DIFF
--- a/aws/alb-ingress.tf
+++ b/aws/alb-ingress.tf
@@ -222,6 +222,17 @@ resource "null_resource" "alb_cleanup_wait" {
     lb_name     = local.alb_load_balancer_name
     aws_region  = var.aws_region
     aws_profile = var.aws_profile_name
+    # Pins the account this ALB lives in, so destroy-time credentials can be
+    # checked against it rather than trusted for being merely valid.
+    aws_account_id = data.aws_caller_identity.current.account_id
+  }
+
+  lifecycle {
+    # Any trigger change replaces this resource, which force-deletes the ALB
+    # below. The profile is a local credential detail, so renaming it must not.
+    # Neither key may force a replacement: that runs the destroy provisioner
+    # below against a live environment.
+    ignore_changes = [triggers["aws_profile"], triggers["aws_account_id"]]
   }
 
   provisioner "local-exec" {
@@ -235,13 +246,57 @@ resource "null_resource" "alb_cleanup_wait" {
       aws_region="${self.triggers.aws_region}"
       aws_profile="${self.triggers.aws_profile}"
 
+      # lookup(), not self.triggers.x: resources created before this key existed
+      # do not have it, and ignore_changes below keeps it that way rather than
+      # replacing them — which would run this very provisioner against a live
+      # environment.
+      expected_account="${lookup(self.triggers, "aws_account_id", "")}"
+
+      # The recorded profile is deliberately not replacement-sensitive, so it can
+      # be stale by destroy time (renamed or removed). Prefer it, fall back to
+      # ambient credentials — but only ever accept credentials for the account
+      # this ALB was created in. Against another account describe-load-balancers
+      # returns LoadBalancerNotFound, so we would report the ALB gone while the
+      # real one survives, or delete a same-named ALB over there.
+      account_of() { aws "$@" sts get-caller-identity --query Account --output text 2>/dev/null || true; }
+
+      use_profile=1
+      if [ -z "$expected_account" ]; then
+        # Predates account pinning. Keep the old behaviour rather than blocking
+        # the destroy; the resource gains the check next time it is replaced.
+        echo "WARNING: no account recorded on this resource; using the first working credentials without an account check."
+        if ! aws sts get-caller-identity --profile "$aws_profile" >/dev/null 2>&1; then
+          use_profile=""
+          aws sts get-caller-identity >/dev/null 2>&1 || {
+            echo "ERROR: no usable AWS credentials." >&2
+            exit 1
+          }
+        fi
+      elif [ "$(account_of --profile "$aws_profile")" != "$expected_account" ]; then
+        use_profile=""
+        if [ "$(account_of)" != "$expected_account" ]; then
+          echo "ERROR: no credentials for account $expected_account; profile '$aws_profile' and the environment both fail or resolve elsewhere." >&2
+          exit 1
+        fi
+        echo "WARNING: profile '$aws_profile' unusable or bound to another account; using ambient credentials for $expected_account."
+      fi
+
+      # Keeps the profile one argument whatever characters it contains.
+      awsx() {
+        if [ -n "$use_profile" ]; then
+          aws --profile "$aws_profile" "$@"
+        else
+          aws "$@"
+        fi
+      }
+
       # Distinguish "ALB not found" from real API errors (auth, throttling, etc.).
       alb_exists() {
         local output
-        output=$(aws elbv2 describe-load-balancers \
+        output=$(awsx elbv2 describe-load-balancers \
           --names "$lb_name" \
           --region "$aws_region" \
-          --profile "$aws_profile" 2>&1)
+          2>&1)
         local rc=$?
         if [ $rc -eq 0 ]; then
           return 0
@@ -260,8 +315,8 @@ resource "null_resource" "alb_cleanup_wait" {
 
       # Give the LB controller up to 5 min to delete the ALB.
       echo "Waiting up to 300s for ALB '$lb_name' to be deleted by the AWS Load Balancer Controller..."
-      end=$((SECONDS + 300))
-      while [ "$SECONDS" -lt "$end" ]; do
+      end=$(($(date +%s) + 300))
+      while [ "$(date +%s)" -lt "$end" ]; do
         if ! alb_exists; then
           echo "ALB '$lb_name' deleted by the controller."
           exit 0
@@ -271,10 +326,9 @@ resource "null_resource" "alb_cleanup_wait" {
 
       # Controller didn't clean up in time — force-delete the ALB.
       echo "WARNING: ALB '$lb_name' still exists after 300s. Force-deleting..."
-      lb_arn=$(aws elbv2 describe-load-balancers \
+      lb_arn=$(awsx elbv2 describe-load-balancers \
         --names "$lb_name" \
         --region "$aws_region" \
-        --profile "$aws_profile" \
         --query 'LoadBalancers[0].LoadBalancerArn' \
         --output text 2>&1) || {
         echo "ERROR: Failed to fetch ALB ARN for '$lb_name' in region '$aws_region' (profile: '$aws_profile'): $lb_arn"
@@ -286,10 +340,10 @@ resource "null_resource" "alb_cleanup_wait" {
         exit 0
       fi
 
-      delete_output=$(aws elbv2 delete-load-balancer \
+      delete_output=$(awsx elbv2 delete-load-balancer \
         --load-balancer-arn "$lb_arn" \
         --region "$aws_region" \
-        --profile "$aws_profile" 2>&1) || {
+        2>&1) || {
         if echo "$delete_output" | grep -q "LoadBalancerNotFound"; then
           echo "ALB was already deleted (race condition). Continuing."
         else
@@ -303,10 +357,9 @@ resource "null_resource" "alb_cleanup_wait" {
       eni_count=""
       end_eni=$((SECONDS + 120))
       while [ "$SECONDS" -lt "$end_eni" ]; do
-        eni_output=$(aws ec2 describe-network-interfaces \
+        eni_output=$(awsx ec2 describe-network-interfaces \
           --filters "Name=description,Values=*ELB app/$${lb_name}/*" \
           --region "$aws_region" \
-          --profile "$aws_profile" \
           --query 'length(NetworkInterfaces)' \
           --output text 2>&1) || {
           echo "WARNING: Failed to query ENIs in region '$aws_region' (profile: '$aws_profile'): $eni_output (will retry)"

--- a/aws/k8s-common.tf
+++ b/aws/k8s-common.tf
@@ -52,9 +52,9 @@ module "k8s_common" {
   ingress_replicas       = local.profile.ingress_replicas
   gdcn_size              = local.profile.gdcn_size
   gdcn_storage_class     = local.storage_class
+  fast_storage_class     = local.fast_storage_class
   pulsar_size            = local.profile.pulsar_size
   observability_size     = local.profile.observability_size
-  fast_storage_class     = local.fast_storage_class
   ai_lake_size_profile   = var.ai_lake_size_profile
   cloud                  = "aws"
   ingress_controller     = var.ingress_controller
@@ -162,5 +162,11 @@ module "k8s_common" {
     aws_iam_role_policy.ai_lake_pod_identity,
     aws_eks_pod_identity_association.ai_lake,
     terraform_data.s3tables_lakeformation_permissions,
+    # Node capacity must outlive the helm releases: deleting the NodePools taints
+    # every Karpenter node, and draining the NodeClaims removes it outright,
+    # either of which leaves pre-delete hooks unschedulable.
+    null_resource.karpenter_nodeclaim_drain,
+    kubectl_manifest.karpenter_node_pool,
+    kubectl_manifest.karpenter_node_pool_starrocks,
   ]
 }

--- a/aws/karpenter.tf
+++ b/aws/karpenter.tf
@@ -211,3 +211,215 @@ resource "kubectl_manifest" "karpenter_node_pool_starrocks" {
 
   depends_on = [kubectl_manifest.karpenter_node_class]
 }
+
+# ---------------------------------------------------------------------------
+# Karpenter destroy-time NodeClaim drain
+# ---------------------------------------------------------------------------
+# Only Karpenter can reap its own nodes, by clearing each NodeClaim finalizer.
+# Removing the controller first orphans them: the instances keep billing and
+# their ENIs block subnet, security group and VPC deletion.
+#
+# Destroy order, enforced by depends_on here and in k8s-common.tf:
+#   helm releases  →  nodeclaim_drain  →  node pools  →  node class  →  karpenter
+# ---------------------------------------------------------------------------
+resource "null_resource" "karpenter_nodeclaim_drain" {
+  triggers = {
+    cluster_name = module.eks.cluster_name
+    aws_region   = var.aws_region
+    aws_profile  = var.aws_profile_name
+    # Pins the account these nodes live in, so destroy-time credentials can be
+    # checked against it before anything is terminated.
+    aws_account_id = data.aws_caller_identity.current.account_id
+  }
+
+  lifecycle {
+    # Any trigger change replaces this resource, which runs the drain below. The
+    # profile is a local credential detail, so renaming it must not delete nodes.
+    # Neither key may force a replacement: that runs the destroy provisioner
+    # below against a live environment.
+    ignore_changes = [triggers["aws_profile"], triggers["aws_account_id"]]
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      set -eu
+
+      command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI not found"; exit 1; }
+      command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+      cluster_name="${self.triggers.cluster_name}"
+      aws_region="${self.triggers.aws_region}"
+      aws_profile="${self.triggers.aws_profile}"
+
+      # lookup(), not self.triggers.x: resources created before this key existed
+      # do not have it, and ignore_changes below keeps it that way rather than
+      # replacing them — which would run this very provisioner against a live
+      # environment.
+      expected_account="${lookup(self.triggers, "aws_account_id", "")}"
+
+      # The recorded profile is deliberately not replacement-sensitive, so it can
+      # be stale by destroy time (renamed or removed). Prefer it, fall back to
+      # ambient credentials — but only ever accept credentials for the account
+      # these nodes live in. This check gates instance termination, so the wrong
+      # account must fail closed rather than act on whatever it can reach.
+      account_of() { aws "$@" sts get-caller-identity --query Account --output text 2>/dev/null || true; }
+
+      use_profile=1
+      if [ -z "$expected_account" ]; then
+        # Predates account pinning. Keep the old behaviour rather than blocking
+        # the destroy; the resource gains the check next time it is replaced.
+        echo "WARNING: no account recorded on this resource; using the first working credentials without an account check."
+        if ! aws sts get-caller-identity --profile "$aws_profile" >/dev/null 2>&1; then
+          use_profile=""
+          aws sts get-caller-identity >/dev/null 2>&1 || {
+            echo "ERROR: no usable AWS credentials." >&2
+            exit 1
+          }
+        fi
+      elif [ "$(account_of --profile "$aws_profile")" != "$expected_account" ]; then
+        use_profile=""
+        if [ "$(account_of)" != "$expected_account" ]; then
+          echo "ERROR: no credentials for account $expected_account; profile '$aws_profile' and the environment both fail or resolve elsewhere." >&2
+          exit 1
+        fi
+        echo "WARNING: profile '$aws_profile' unusable or bound to another account; using ambient credentials for $expected_account."
+      fi
+
+      # Keeps the profile one argument whatever characters it contains.
+      awsx() {
+        if [ -n "$use_profile" ]; then
+          aws --profile "$aws_profile" "$@"
+        else
+          aws "$@"
+        fi
+      }
+
+      # Terminate any instance Karpenter still owns. Only needs the EC2 API, so
+      # it is also the fallback when the cluster itself is unreachable.
+      force_terminate_instances() {
+        ids=$(awsx ec2 describe-instances --region "$aws_region" \
+          --filters "Name=tag:kubernetes.io/cluster/$cluster_name,Values=owned" \
+                    "Name=tag-key,Values=karpenter.sh/nodeclaim" \
+                    "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+          --query 'Reservations[].Instances[].InstanceId' --output text) || {
+          echo "ERROR: cannot list Karpenter instances to force-terminate." >&2
+          exit 1
+        }
+
+        if [ -z "$ids" ]; then
+          echo "No Karpenter-owned instances remain."
+          return 0
+        fi
+
+        echo "Terminating $ids"
+        awsx ec2 terminate-instances --region "$aws_region" \
+          --instance-ids $ids >/dev/null || {
+          echo "ERROR: terminate-instances failed." >&2
+          exit 1
+        }
+        # ENIs only detach once instances reach terminated, and they block
+        # subnet, security group and VPC deletion until they do.
+        echo "Waiting for termination so their ENIs are released..."
+        awsx ec2 wait instance-terminated --region "$aws_region" \
+          --instance-ids $ids || echo "WARNING: waiter timed out; VPC deletion may retry."
+      }
+
+      kubeconfig=$(mktemp)
+      trap 'rm -f "$kubeconfig"' EXIT
+
+      # Distinguish an already-deleted cluster from a real API error (expired
+      # credentials, wrong profile, no network), which must not skip the drain.
+      if ! err=$(awsx eks update-kubeconfig --name "$cluster_name" --region "$aws_region" \
+        --kubeconfig "$kubeconfig" 2>&1); then
+        if echo "$err" | grep -q "ResourceNotFoundException"; then
+          echo "Cluster '$cluster_name' no longer exists; checking for orphaned instances."
+          force_terminate_instances
+          exit 0
+        fi
+        echo "ERROR: cannot reach cluster '$cluster_name' in '$aws_region': $err" >&2
+        exit 1
+      fi
+
+      # --request-timeout: kubectl defaults to 0 (wait forever), so a blackholed
+      # API server would hang the destroy instead of falling through to EC2.
+      kc="kubectl --kubeconfig $kubeconfig --request-timeout=15s"
+
+      # Unreachable API means Karpenter cannot reap its own nodes, so do it via
+      # EC2 instead. Exiting here would strand instances whose ENIs then block
+      # subnet, security group and VPC deletion.
+      if ! $kc get --raw /readyz >/dev/null 2>&1; then
+        echo "WARNING: cluster '$cluster_name' is unreachable; terminating its instances directly."
+        force_terminate_instances
+        exit 0
+      fi
+
+      if ! $kc get crd nodeclaims.karpenter.sh >/dev/null 2>&1; then
+        echo "NodeClaim CRD not installed; checking for orphaned instances."
+        force_terminate_instances
+        exit 0
+      fi
+
+      # Fails instead of printing 0 when the API call itself fails, so a
+      # transient error is never mistaken for an empty cluster.
+      count_claims() {
+        out=$($kc get nodeclaims --no-headers 2>/dev/null) || return 1
+        if [ -z "$out" ]; then echo 0; else echo "$out" | wc -l | tr -d ' '; fi
+      }
+
+      if ! remaining=$(count_claims); then
+        echo "ERROR: cannot list NodeClaims on '$cluster_name'." >&2
+        exit 1
+      fi
+      if [ "$remaining" = "0" ]; then
+        echo "No NodeClaims to drain."
+        exit 0
+      fi
+
+      echo "Deleting $remaining Karpenter NodeClaim(s)..."
+      $kc delete nodeclaims --all --wait=false >/dev/null 2>&1 || true
+
+      # The finalizer clears only after the instance is terminated, so a claim
+      # disappearing means its node is really gone.
+      echo "Waiting up to 900s for Karpenter to terminate them..."
+      i=0
+      while [ "$i" -lt 90 ]; do
+        if remaining=$(count_claims); then
+          if [ "$remaining" = "0" ]; then
+            echo "All NodeClaims drained."
+            exit 0
+          fi
+          echo "Still waiting for $remaining NodeClaim(s)..."
+        else
+          echo "WARNING: could not list NodeClaims, retrying..."
+        fi
+        sleep 10
+        i=$((i + 1))
+      done
+
+      # Karpenter is wedged. Failing here would leave the stack undestroyable,
+      # so do its job directly: terminate the instances, then clear finalizers.
+      echo "WARNING: NodeClaim(s) still present after 900s; forcing cleanup."
+
+      # Terminate before clearing finalizers, so no instance is left orphaned.
+      force_terminate_instances
+
+      # Karpenter clears the finalizer only after it observes the instance gone,
+      # which it cannot do once it has lost EC2 API reachability.
+      for nc in $($kc get nodeclaims -o name 2>/dev/null); do
+        $kc patch "$nc" --type=merge -p '{"metadata":{"finalizers":null}}' >/dev/null 2>&1 || true
+      done
+
+      echo "Forced cleanup complete."
+    EOT
+  }
+
+  # Node egress must outlive the drain: kubelets reach the public EKS endpoint
+  # and Karpenter the EC2 API over module.vpc's NAT gateway.
+  depends_on = [
+    kubectl_manifest.karpenter_node_pool,
+    kubectl_manifest.karpenter_node_pool_starrocks,
+    module.vpc,
+    aws_vpc_endpoint.s3,
+  ]
+}

--- a/azure/aks.tf
+++ b/azure/aks.tf
@@ -56,11 +56,10 @@ resource "azurerm_kubernetes_cluster" "main" {
     tags = local.common_tags
   }
 
-  # Node Auto Provisioning (NAP / managed Karpenter) replaces the cluster
-  # autoscaler. mode=Auto installs and manages Karpenter in the control plane;
-  # default_node_pools=None means the only NodePools are the ones we define
-  # ourselves (see karpenter.tf). NAP cannot coexist with the cluster
-  # autoscaler, so node-pool autoscaling and auto_scaler_profile are removed.
+  # Node Auto Provisioning (NAP / managed Karpenter): mode=Auto installs and
+  # manages Karpenter in the control plane; default_node_pools=None means the
+  # only NodePools are the ones we define (karpenter.tf). NAP cannot coexist
+  # with the cluster autoscaler, so node-pool autoscaling must stay unset.
   node_provisioning_profile {
     mode               = "Auto"
     default_node_pools = "None"
@@ -72,7 +71,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   # Azure CNI Overlay powered by Cilium: pods get IPs from pod_cidr, not the AKS
-  # subnet, so node count is no longer subnet-bound. Overlay requires Cilium (not NPM).
+  # subnet, so node count isn't subnet-bound. Overlay requires Cilium (not NPM).
   network_profile {
     network_plugin      = "azure"
     network_plugin_mode = "overlay"
@@ -92,9 +91,12 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   tags = local.common_tags
 
-  # NAT gateway must be attached to the subnet before the cluster is created
-  # when outbound_type = userAssignedNATGateway.
-  depends_on = [azurerm_subnet_nat_gateway_association.aks]
+  # userAssignedNATGateway egress needs both bound before creation, and keeps node
+  # egress alive until the cluster is destroyed.
+  depends_on = [
+    azurerm_nat_gateway_public_ip_association.main,
+    azurerm_subnet_nat_gateway_association.aks,
+  ]
 }
 
 # The kubelet identity gets no resource-group-wide grant: any pod can reach it

--- a/modules/k8s-aws/external-dns.tf
+++ b/modules/k8s-aws/external-dns.tf
@@ -113,10 +113,16 @@ resource "helm_release" "external_dns" {
   wait_for_jobs = true
   timeout       = 1800
 
+  # Tolerate the system pool taint: this runs before Karpenter has provisioned
+  # any untainted capacity, so the system nodes are the only place it can land.
   values = [yamlencode({
     image = {
       repository = "${var.registry_k8sio}/external-dns/external-dns"
     }
+    tolerations = [{
+      key      = "CriticalAddonsOnly"
+      operator = "Exists"
+    }]
     provider      = "aws"
     policy        = "sync"
     registry      = "txt"

--- a/modules/k8s-aws/lb-controller.tf
+++ b/modules/k8s-aws/lb-controller.tf
@@ -267,6 +267,8 @@ resource "helm_release" "aws_load_balancer_controller" {
   wait_for_jobs = true
   timeout       = 1800
 
+  # Tolerate the system pool taint: this runs before Karpenter has provisioned
+  # any untainted capacity, so the system nodes are the only place it can land.
   values = [<<EOF
     replicaCount: ${var.ingress_replicas}
     clusterName: ${var.deployment_name}
@@ -275,6 +277,9 @@ resource "helm_release" "aws_load_balancer_controller" {
     serviceAccount:
       create: false
       name: aws-load-balancer-controller
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
 EOF
   ]
 

--- a/modules/k8s-aws/metrics-server.tf
+++ b/modules/k8s-aws/metrics-server.tf
@@ -17,9 +17,14 @@ resource "helm_release" "metrics-server" {
   wait          = true
   wait_for_jobs = true
   timeout       = 1800
+  # Tolerate the system pool taint: this runs before Karpenter has provisioned
+  # any untainted capacity, so the system nodes are the only place it can land.
   values = [<<EOF
 image:
   repository: ${var.registry_k8sio}/metrics-server/metrics-server
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
 EOF
   ]
 }

--- a/modules/k8s-common/gooddata-orgs.tf
+++ b/modules/k8s-common/gooddata-orgs.tf
@@ -149,6 +149,15 @@ resource "kubectl_manifest" "gdcn_organization" {
     }, each.value.tls)
   })
 
+  # Block destroy until the controller clears its kopf finalizer, which it can only
+  # do while the gooddata-cn release is still running.
+  #
+  # Unbounded on purpose, because it cannot be bounded: kubectl_manifest's
+  # timeouts block only accepts `create`. If a wedged finalizer ever hangs a
+  # destroy, interrupt it and clear the finalizer by hand:
+  #   kubectl patch organization <id> --type=merge -p '{"metadata":{"finalizers":null}}'
+  wait = true
+
   lifecycle {
     precondition {
       condition     = each.value.name != ""


### PR DESCRIPTION
**Stack 6/7** — split out of #230. Base: #5 (`stack/5-storage`).

**Create side:** external-dns, the load balancer controller and metrics-server tolerate the system pool's `CriticalAddonsOnly` taint, so they can land before Karpenter has provisioned any workload capacity.

**Destroy side:**
- **Karpenter drain.** Only Karpenter can clear a NodeClaim finalizer, so removing the controller first orphans the instances and their ENIs block subnet, security group and VPC deletion. The drain sits in the dependency chain and falls back to terminating tagged instances via EC2 whenever the cluster API is unreachable. Credentials are bound to the account recorded at apply time and **fail closed** against any other — wrong-account credentials would otherwise terminate someone else's instances.
- **ALB cleanup** waits for the controller to finish, then force-deletes and waits for the ENIs to detach.
- **gooddata-orgs** waits so the controller can clear its kopf finalizer while the release is still running.
- **AKS** keeps node egress alive until the cluster is destroyed, by depending on both NAT gateway associations.

This is destroy-path code CI never exercises, so it deserves a read rather than a skim. #7 moves the shell out of the heredocs and makes it testable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer cleanup for AWS load balancers and Karpenter-managed nodes during infrastructure removal.
  * Improved cleanup handling for missing clusters, unavailable tools, lingering nodes, and stalled resources.

* **Bug Fixes**
  * System services can now run on nodes reserved for critical add-ons.
  * Improved cluster creation ordering for Azure networking resources.
  * Organization deletion now waits for controller cleanup to complete.
  * AWS cleanup now validates account credentials before making changes.

* **Documentation**
  * Clarified node autoscaling, network configuration, and system-pool scheduling requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->