### PR TITLE
fix(observability): guarantee promtail schedules on every node

### DIFF
--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -217,6 +217,15 @@ resource "helm_release" "promtail" {
           url = "http://loki.observability.svc.cluster.local:3100/loki/api/v1/push"
         }]
       }
+      # Log collection must never lose a node: outrank workloads so promtail
+      # preempts them on a full node instead of staying Pending.
+      priorityClassName = "system-node-critical"
+      # Tolerate every taint so tainted/dedicated node pools still ship logs.
+      tolerations = [
+        { key = "node-role.kubernetes.io/master", operator = "Exists", effect = "NoSchedule" },
+        { key = "node-role.kubernetes.io/control-plane", operator = "Exists", effect = "NoSchedule" },
+        { operator = "Exists" },
+      ]
       resources = {
         requests = {
           cpu    = "50m"


### PR DESCRIPTION
## Problem

promtail ran at **priority 0** with only control-plane tolerations. On a node whose CPU/memory
requests were fully consumed by workload pods, promtail stayed `Pending` and **that node shipped no
logs at all**.

Observed on a freshly provisioned Karpenter node:

```
0/16 nodes are available: 1 Insufficient cpu, 1 Insufficient memory,
15 node(s) didn't satisfy plugin(s) [NodeAffinity].
preemption: 0/16 nodes are available: 1 No preemption victims found for incoming pod
```

The 15 NodeAffinity rejections are normal — a DaemonSet pod is pinned to one node. The problem is the
one node that matched was at 100% of CPU requests and 99% of memory, and at priority 0 there was
nothing lower-priority to evict.

## Change

- `priorityClassName: system-node-critical` (2000001000) so the scheduler preempts workload pods
  instead of leaving promtail Pending. This is the class every other node-level DaemonSet on the
  cluster already uses (cilium, azure-cns, csi-azuredisk-node, cloud-node-manager); promtail,
  node-exporter and loki-canary were the only ones at priority 0.
- A catch-all toleration, since the chart's defaults cover only control-plane taints — any tainted or
  dedicated node pool would silently ship no logs, same symptom, different cause.

## Verification

Values confirmed to land in the rendered DaemonSet via `helm template` against chart 6.17.1, rather
than assuming the chart honours them. No `ResourceQuota` in the `observability` namespace, which is
the one thing that can stop a non-`kube-system` namespace using `system-node-critical`.

`terraform fmt -recursive` clean, `terraform -chdir=azure validate` passes.

## Trade-off worth knowing

This lets promtail evict GoodData.CN pods on a saturated node. That is the intended trade — losing
logs from the busiest node is how you get blind spots exactly when you need them — but it is real, and
worth flagging to anyone running load tests.

`node-exporter` and `loki-canary` have the identical exposure and are not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Promtail scheduling so log collection can run on critical and tainted nodes, including control-plane nodes.

* **Reliability**
  * Log collection is better protected from resource constraints and node taints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->