### PR TITLE
feat(observability): export node labels via kube_node_labels

### DIFF
--- a/modules/k8s-common/observability.tf
+++ b/modules/k8s-common/observability.tf
@@ -47,9 +47,14 @@ resource "helm_release" "kube_prometheus_stack" {
       kubeStateMetrics = { enabled = true }
       nodeExporter     = { enabled = true }
 
-      # Subchart image overrides
+      # Subchart overrides
       "kube-state-metrics" = {
         image = { registry = var.registry_k8sio }
+        # Opt node labels into kube_node_labels (VM size, zone/region, Karpenter
+        # nodepool). Scoped rather than nodes=[*] to keep cardinality bounded.
+        metricLabelsAllowlist = [
+          "nodes=[node.kubernetes.io/instance-type,topology.kubernetes.io/zone,topology.kubernetes.io/region,karpenter.sh/nodepool]"
+        ]
       }
       "prometheus-node-exporter" = {
         image = { registry = var.registry_quayio }


### PR DESCRIPTION
## Problem

kube-state-metrics v2 exports **no** node labels unless opted in, so `kube_node_labels` had **zero
series** on deployed clusters. Dashboards could not show a node's VM size, and sizing had to be
inferred from `kube_node_status_capacity{resource="cpu"}` — which cannot distinguish SKUs that share a
vCPU/memory ratio, and tells you nothing about zone or nodepool.

This came up while diagnosing node OS-disk saturation, where "is this a 4 or a 16 vCPU node" was the
first question and the cluster could not answer it.

## Change

Adds `metricLabelsAllowlist` under the `kube-state-metrics` subchart, scoped to four labels:

```
nodes=[node.kubernetes.io/instance-type,
       topology.kubernetes.io/zone,
       topology.kubernetes.io/region,
       karpenter.sh/nodepool]
```

Dashboards can then join on:

```promql
... * on(node) group_left(label_node_kubernetes_io_instance_type) kube_node_labels
```

## Why scoped rather than `nodes=[*]`

Karpenter/NAP nodes carry dozens of labels including churn-prone ones (`karpenter.sh/nodepool-hash`,
`kubernetes.azure.com/*`, full instance feature labels). `[*]` would inflate the series' label set and
mint a new series on every node roll. Four low-churn labels means one series per node with four extra
dimensions — negligible cardinality.

## Verification

Chart is `kube-prometheus-stack` **88.3.0**, bundled `kube-state-metrics` 8.2.0 / appVersion 2.19.1 —
no version bump needed. The values key differs across versions (`metricLabelsAllowlist` vs
`extraArgs`), so it was verified rather than assumed:

1. `charts/kube-state-metrics/values.yaml:410` declares `metricLabelsAllowlist: []`
2. `templates/deployment.yaml:100-102` renders it as `--metric-labels-allowlist=`
3. `helm template` with this value emits the flag verbatim on `kube-state-metrics:v2.19.1`
4. the `nodes` collector is in the subchart's default collector list and is not overridden here

`terraform fmt -recursive` clean, `terraform -chdir=azure validate` passes.

## Caveats

- AKS system-pool nodes have no `karpenter.sh/nodepool`, so that label renders empty for them. Adding
  `kubernetes.azure.com/agentpool` would name them, at the cost of making the allowlist cloud-specific.
- Applying restarts the kube-state-metrics pod (args change); existing series are unaffected beyond
  the scrape gap.
- This is a subchart-level key, and Helm ignores unknown subchart keys silently. A future
  kube-prometheus-stack major that renames the dependency would drop it with no error — worth a check
  on major bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node observability metrics now include labels for instance type, zone, region, and Karpenter node pool.
* **Improvements**
  * Enhanced visibility into node configuration and placement through exported metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->