### PR TITLE
perf(azure): size node OS disks for 5000 IOPS

### DIFF
--- a/azure/karpenter.tf
+++ b/azure/karpenter.tf
@@ -1,14 +1,14 @@
 ###
-# Karpenter provisioning policy for Node Auto Provisioning (NAP)
+# Karpenter provisioning policy for Node Auto Provisioning (NAP).
 #
-# NAP (enabled on the cluster in aks.tf) installs and manages the Karpenter
-# controller and its CRDs in the AKS control plane. We only supply the
-# provisioning policy: an AKSNodeClass (how nodes are built) and a NodePool
-# (what may be provisioned). Because the cluster sets default_node_pools=None,
-# these are the only NodePools.
+# AKS runs the Karpenter controller and CRDs; we supply only the policy. The
+# AKSNodeClass says how nodes are built, the NodePool what may be provisioned.
+# The cluster sets default_node_pools=None, so these are the only NodePools.
 ###
 
-# How NAP builds nodes: Ubuntu 22.04 image, 100 GB OS disk.
+# Node OS disk holds every emptyDir, including Quiver's flight catalog, which is
+# I/O heavy. Premium SSD v1 IOPS scale only with capacity, so 1TiB buys P30's
+# 5000 IOPS / 200 MBps; 100GB would cap the whole node at P10's 500 IOPS.
 resource "kubectl_manifest" "karpenter_node_class" {
   yaml_body = yamlencode({
     apiVersion = "karpenter.azure.com/v1beta1"
@@ -18,7 +18,7 @@ resource "kubectl_manifest" "karpenter_node_class" {
     }
     spec = {
       imageFamily  = "Ubuntu2204"
-      osDiskSizeGB = 100
+      osDiskSizeGB = 1024
     }
   })
 
@@ -28,17 +28,10 @@ resource "kubectl_manifest" "karpenter_node_class" {
   ]
 }
 
-# General-purpose NodePool: on-demand AMD general-purpose D-series with a
-# per-node vCPU cap (size-profiles.tf). We pin sku-series (not the broad "D"
-# family) to keep the fleet homogeneous: AMD only, 4 GiB/vCPU only. The bare "D"
-# family conflates three things we do not want — Intel parts (Ds/Dls), and the
-# low-memory 2 GiB/vCPU "l" series (Dals/Dls) — none of which carry a vendor or
-# memory-ratio label to filter on, so the series allow-list is the only handle.
-# All listed series are premium-storage capable, which in Azure costs the same
-# per hour as the (now v4-only) non-premium variants, so there is no reason to
-# admit non-premium SKUs and force premium-PVC pods onto per-pod nodeAffinity.
-# v6/v7 only, so nodes are always current-generation. sku-cpu + the CPU limit
-# bound node size and total cost.
+# General-purpose NodePool: on-demand AMD D-series, 4 GiB/vCPU, v6/v7 only.
+# The series allow-list is the only way to exclude Intel (Ds/Dls) and the
+# low-memory "l" series (Dals/Dls); neither carries a label to filter on.
+# sku-cpu and the NodePool CPU limit bound per-node size and total fleet cost.
 resource "kubectl_manifest" "karpenter_node_pool" {
   yaml_body = yamlencode({
     apiVersion = "karpenter.sh/v1"

--- a/azure/storage-class.tf
+++ b/azure/storage-class.tf
@@ -1,13 +1,11 @@
 ###
-# Kubernetes storage classes for AKS
+# AKS StorageClasses for PVCs. Node OS disks are sized in aks.tf and karpenter.tf.
 ###
 
-# Premium SSD v2 (PremiumV2_LRS), referenced explicitly by the prod size
-# profiles (see size-profiles.tf). NOT the cluster default — every PVC sets its
-# class by name per profile. v2 lets IOPS/throughput scale independently of disk
-# size; 3000 IOPS / 125 MBps is the free baseline. Requires zonal nodes (see
-# aks.tf zones) and isn't available in every region. WaitForFirstConsumer aligns
-# the disk to the pod's zone.
+# Premium SSD v2: IOPS and throughput are provisioned independently of capacity.
+# 3000 IOPS / 125 MBps is the free floor; the paid ceiling is 500 IOPS per GiB.
+# Named explicitly by the prod size profiles, so it is not the cluster default.
+# Needs zonal nodes and is unavailable in some regions.
 resource "kubernetes_storage_class_v1" "premium_ssd_v2" {
   metadata {
     name = "premium-ssd-v2"
@@ -34,8 +32,8 @@ resource "kubernetes_storage_class_v1" "premium_ssd_v2" {
   ]
 }
 
-# Premium SSD v1 (Premium_LRS) kept as a non-default class so workloads can pin
-# to it explicitly (e.g. where v2 is unavailable or snapshots are needed).
+# Premium SSD v1: IOPS follow capacity alone (128GiB=500, 512GiB=2300, 1TiB=5000).
+# Non-default, for workloads needing snapshots or a region without v2.
 resource "kubernetes_storage_class_v1" "premium_ssd" {
   metadata {
     name = "premium-ssd"
@@ -60,12 +58,8 @@ resource "kubernetes_storage_class_v1" "premium_ssd" {
   ]
 }
 
-# Cluster default = the built-in StandardSSD class "managed-csi" (standard tier).
-# GoodData.CN / Pulsar / observability PVCs all set their class explicitly per
-# size_profile, so this default only catches anything otherwise unset. The other
-# built-in "default" class (also StandardSSD) is demoted so exactly one default
-# remains. These classes are owned by AKS; only the is-default-class annotation
-# is patched via server-side apply.
+# Make managed-csi the one cluster default and demote the built-in "default"
+# class. Only catches PVCs that set no class, since our charts all set one.
 resource "kubernetes_annotations" "default_storage_class" {
   for_each = {
     "default"     = "false"
@@ -83,8 +77,8 @@ resource "kubernetes_annotations" "default_storage_class" {
     "storageclass.kubernetes.io/is-default-class" = each.value
   }
 
-  # The built-in classes carry this annotation from a different field manager;
-  # take ownership of it rather than erroring on the conflict.
+  # AKS owns these classes and sets this annotation from another field manager;
+  # take ownership rather than failing on the conflict.
   force = true
 
   depends_on = [


### PR DESCRIPTION
## Problem

Quiver keeps its SQLite flight catalog on an `emptyDir`, which lives on the **node OS disk**
(`/var/lib/kubelet` on `/dev/root`). `AKSNodeClass` set a fixed 100GB disk and exposes no disk-type or
IOPS field, so every node got Premium SSD v1 **P10 at 500 IOPS** regardless of its size.

The result is perverse: Karpenter bin-packs more pods onto bigger nodes, but the IOPS budget never
grows.

| VM size | vCPU | VM can do | OS disk delivers |
|---|---|---|---|
| Standard_D4as_v6 | 4 | 7,600 IOPS | **500** |
| Standard_D16as_v6 | 16 | 30,400 IOPS | **500** |

A 16 vCPU node hosting 9 pods (2 quiver-cache, 3 quiver-xtab, 2 result-cache, 2 sql-executor) shares
one 500-IOPS disk — **1.6% of what the VM supports**.

## Evidence

Measured on a loaded node over 2.5h of load testing:

| | suspect node | control node |
|---|---|---|
| write IOPS | **510 / 510 / 510** (min/median/max, 76 samples) | 340 / 697 / 1488 |
| disk busy | 100% | varies |
| true write await | **94.7 ms** | 20.7 ms |
| service time | 1.96 ms | — |
| PSI, capacity lost to I/O wait | **62%** | 20% |

A dead-flat IOPS line with zero variance is an enforced cap, not organic load — 101 of 180 samples
over 6h sat in the 505–515 band. Confirmed against the Azure API: every node OS disk is
`Premium_LRS, 100GiB, tier=P10, iops=500, mbps=100`, managed (not ephemeral), `caching: None`.

Burst credits mask this for ~30 minutes (P10 bursts to 3,500 IOPS from a 6,084,000-IO bucket, refilling
at ≤500/s so ~3.4h to restore). **That is why the first load test of the day looks healthy and later
ones do not.**

## Sizing

Not a guess. Queue depth is constant at ~48 regardless of service rate, so this is a closed loop and
Little's Law applies — validated at both ends:

```
IOPS   queue   await     queue/await
3567    48.2   13.5ms  ->  3567   ✓
 511    48.3   94.7ms  ->   510   ✓
```

| target await | required IOPS |
|---|---|
| 50 ms | 966 |
| 20 ms | 2,415 |
| **10 ms** | **4,829** |

So doubling (1,000) buys ~48 ms and tripling (1,500) ~32 ms — neither is meaningfully better than
today's burst behaviour. 1024GiB selects the **P30** tier at **5000 IOPS / 200 MB/s**, landing at
~10 ms.

Demand genuinely exceeds 3,500: queue depth is identical at 511 and 3,567 IOPS, so the queue will
still be ~48 deep after this change. This buys ~10 ms, not ~1 ms.

## Rollout

Karpenter replaces existing nodes via `NodeClassDrift`, paced by the NodePool's 10% disruption budget
— roughly one node at a time. The fleet is mixed during the roll, so a test that lands Quiver pods on
an old node will look unchanged. Verify with `kubectl get nodes -o custom-columns=...ephemeral-storage`:
old nodes read ~96Gi, new ones ~992Gi.

## Cost

**+$105/node/month** in East US 2, +$127 in West Europe (Azure retail API). At 22 nodes that is
~$2.3k/month. Unit economics improve ($35.84 → $24.58 per 1k IOPS/month) but ~900GB of capacity is
bought and never used, because Premium SSD v1 bundles IOPS with capacity and there is no way to
unbundle for an OS disk — `AKSNodeClass` has no SKU or IOPS field.

**A much cheaper fix exists and needs a chart change, not a Terraform change.** A 10GiB Premium SSD v2
PVC gives the same 5000 IOPS for **$14/node/month** (v2 bills capacity, IOPS and throughput separately
and caps at 500 IOPS/GiB). Today it is unreachable: `gooddata-common/templates/quiver/_statefulset-cache.tpl:261-266`
hardcodes the catalog volume as `emptyDir` with no PVC branch. If Quiver adds a `persistence` option
for `quiver.storage`, this change should be reverted in favour of that.

## Also

Comments in both files rewritten to state the mechanism rather than the history, and
`storage-class.tf` now cross-references where node OS disks are sized — conflating them with the PVC
StorageClasses is what hid this in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Increased the AKS node operating system disk capacity from 100 GB to 1 TiB, providing additional space for workloads and system operations.

* **Documentation**
  * Clarified storage class behavior, including Premium SSD options, regional and workload considerations, default settings, and annotation conflicts.
  * Improved documentation around node pool selection and the rationale for the larger OS disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->